### PR TITLE
Move HyphenateHttpHeadersRule from .zalando to .zally package

### DIFF
--- a/server/rules.md
+++ b/server/rules.md
@@ -21,3 +21,7 @@ Unused definitions cause confusion and should be avioded.
 ## H001: Base path can be extracted
 
 If all paths start with the same prefix then it would be cleaner to extract that into the basePath rather than repeating for each path.
+
+## 131: Use Hyphenated HTTP Headers
+
+Header names should be hyphenated rather than use underscores or other separators

--- a/server/src/main/java/de/zalando/zally/rule/zalando/HttpHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/HttpHeadersRule.kt
@@ -2,12 +2,13 @@ package de.zalando.zally.rule.zalando
 
 import com.typesafe.config.Config
 import de.zalando.zally.rule.AbstractRule
+import de.zalando.zally.rule.api.RuleSet
 import de.zalando.zally.rule.api.Violation
 import io.swagger.models.Response
 import io.swagger.models.Swagger
 import io.swagger.models.parameters.Parameter
 
-abstract class HttpHeadersRule(ruleSet: ZalandoRuleSet, rulesConfig: Config) : AbstractRule(ruleSet) {
+abstract class HttpHeadersRule(ruleSet: RuleSet, rulesConfig: Config) : AbstractRule(ruleSet) {
 
     private val headersWhitelist = rulesConfig.getStringList(HttpHeadersRule::class.simpleName + ".whitelist").toSet()
 

--- a/server/src/main/java/de/zalando/zally/rule/zally/HyphenateHttpHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/HyphenateHttpHeadersRule.kt
@@ -1,16 +1,17 @@
-package de.zalando.zally.rule.zalando
+package de.zalando.zally.rule.zally
 
 import com.typesafe.config.Config
 import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
+import de.zalando.zally.rule.zalando.HttpHeadersRule
 import de.zalando.zally.util.PatternUtil
 import io.swagger.models.Swagger
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class HyphenateHttpHeadersRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : HttpHeadersRule(ruleSet, rulesConfig) {
+class HyphenateHttpHeadersRule(@Autowired ruleSet: ZallyRuleSet, @Autowired rulesConfig: Config) : HttpHeadersRule(ruleSet, rulesConfig) {
     override val title = "Use Hyphenated HTTP Headers"
     override val id = "131"
     override val severity = Severity.MUST

--- a/server/src/test/java/de/zalando/zally/rule/zally/HyphenateHttpHeadersRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/HyphenateHttpHeadersRuleTest.kt
@@ -1,4 +1,4 @@
-package de.zalando.zally.rule.zalando
+package de.zalando.zally.rule.zally
 
 import de.zalando.zally.getFixture
 import de.zalando.zally.swaggerWithHeaderParams
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class HyphenateHttpHeadersRuleTest {
 
-    private val rule = HyphenateHttpHeadersRule(ZalandoRuleSet(), testConfig)
+    private val rule = HyphenateHttpHeadersRule(ZallyRuleSet(), testConfig)
 
     @Test
     fun simplePositiveCase() {


### PR DESCRIPTION
Moved as discussed in #607.

We could change the id 131 to ZallyRuleSet style (M131??) but that would break any existing "ignore" configurations. I've left it alone for now but am happy to be directed otherwise.
