### PR TITLE
Test rules have unique names and a distinct RuleSet

### DIFF
--- a/server/src/test/java/de/zalando/zally/TestRuleSet.kt
+++ b/server/src/test/java/de/zalando/zally/TestRuleSet.kt
@@ -1,0 +1,19 @@
+package de.zalando.zally
+
+import de.zalando.zally.rule.api.Rule
+import de.zalando.zally.rule.api.RuleSet
+import org.springframework.stereotype.Component
+import java.net.URI
+
+@Component
+class TestRuleSet : RuleSet {
+    override val id = javaClass.simpleName
+    override val title = "Zally Test Rules"
+    override val url = URI.create("https://test.example.com")
+    override fun url(rule: Rule): URI {
+        val ref = "${rule.id}: ${rule.title}"
+                .toLowerCase()
+                .replace(Regex("[^a-z0-9]+"), "-")
+        return url.resolve("#$ref")
+    }
+}

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiIgnoreRulesTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiIgnoreRulesTest.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import static de.zalando.zally.util.ResourceUtil.readApiDefinition;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@TestPropertySource(properties = "zally.ignoreRules=H999")
+@TestPropertySource(properties = "zally.ignoreRules=TAlwaysGiveAHintRule")
 public class RestApiIgnoreRulesTest extends RestApiBaseTest {
 
     @Test

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
@@ -1,20 +1,18 @@
 package de.zalando.zally.apireview;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import de.zalando.zally.rule.api.Severity;
+import de.zalando.zally.TestRuleSet;
 import de.zalando.zally.rule.AbstractRule;
 import de.zalando.zally.rule.ApiValidator;
 import de.zalando.zally.rule.CompositeRulesValidator;
 import de.zalando.zally.rule.JsonRulesValidator;
 import de.zalando.zally.rule.SwaggerRulesValidator;
-import de.zalando.zally.rule.api.Violation;
 import de.zalando.zally.rule.api.Check;
 import de.zalando.zally.rule.api.Rule;
-import de.zalando.zally.rule.api.RuleSet;
+import de.zalando.zally.rule.api.Severity;
+import de.zalando.zally.rule.api.Violation;
 import de.zalando.zally.rule.zalando.InvalidApiSchemaRule;
-import de.zalando.zally.rule.zalando.ZalandoRuleSet;
 import io.swagger.models.Swagger;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,18 +33,20 @@ public class RestApiTestConfiguration {
     @Primary
     @Profile("test")
     public ApiValidator validator() {
+        final TestRuleSet ruleSet = new TestRuleSet();
         final List<Rule> rules = Arrays.asList(
-            new CheckApiNameIsPresentRule("Product Service"),
-            new AlwaysGiveAHintRule()
+            new CheckApiNameIsPresentRule(ruleSet),
+            new AlwaysGiveAHintRule(ruleSet),
+            new CheckApiNameIsPresentJsonRule(ruleSet)
         );
         return new CompositeRulesValidator(
                 new SwaggerRulesValidator(rules, invalidApiRule),
-                new JsonRulesValidator(Arrays.asList(new CheckApiNameIsPresentJsonRule(new ZalandoRuleSet())), invalidApiRule));
+                new JsonRulesValidator(rules, invalidApiRule));
     }
 
     public static class CheckApiNameIsPresentJsonRule extends AbstractRule {
 
-        public CheckApiNameIsPresentJsonRule(@NotNull RuleSet ruleSet) {
+        public CheckApiNameIsPresentJsonRule(TestRuleSet ruleSet) {
             super(ruleSet);
         }
 
@@ -68,7 +68,7 @@ public class RestApiTestConfiguration {
 
         @Override
         public String getId() {
-            return "166";
+            return "T" + getClass().getSimpleName();
         }
 
         @Override
@@ -79,16 +79,13 @@ public class RestApiTestConfiguration {
 
     public static class CheckApiNameIsPresentRule extends AbstractRule {
 
-        private final String apiName;
-
-        CheckApiNameIsPresentRule(String apiName) {
-            super(new ZalandoRuleSet());
-            this.apiName = apiName;
+        public CheckApiNameIsPresentRule(TestRuleSet ruleSet) {
+            super(ruleSet);
         }
 
         @Check(severity = Severity.MUST)
         public Violation validate(Swagger swagger) {
-            if (swagger != null && swagger.getInfo().getTitle().contains(apiName)) {
+            if (swagger != null && swagger.getInfo().getTitle().contains("Product Service")) {
                 return new Violation("dummy", Collections.emptyList());
             } else {
                 return null;
@@ -102,7 +99,7 @@ public class RestApiTestConfiguration {
 
         @Override
         public String getId() {
-            return "999";
+            return "T" + getClass().getSimpleName();
         }
 
         @Override
@@ -113,8 +110,8 @@ public class RestApiTestConfiguration {
     }
 
     public static class AlwaysGiveAHintRule extends AbstractRule {
-        public AlwaysGiveAHintRule() {
-            super(new ZalandoRuleSet());
+        public AlwaysGiveAHintRule(TestRuleSet ruleSet) {
+            super(ruleSet);
         }
 
         @Check(severity = Severity.HINT)
@@ -129,7 +126,7 @@ public class RestApiTestConfiguration {
 
         @Override
         public String getId() {
-            return "H999";
+            return "T" + getClass().getSimpleName();
         }
 
         @Override

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
@@ -101,7 +101,7 @@ public class RestApiViolationsTest extends RestApiBaseTest {
     @Test
     public void shouldIgnoreRulesWithApiParameter() throws IOException {
         ApiDefinitionRequest request = readApiDefinition("fixtures/api_spp.json");
-        request.setIgnoreRules(Arrays.asList("166", "999"));
+        request.setIgnoreRules(Arrays.asList("TCheckApiNameIsPresentJsonRule", "TCheckApiNameIsPresentRule"));
         ApiDefinitionResponse response = sendApiDefinition(request);
 
         List<ViolationDTO> violations = response.getViolations();

--- a/server/src/test/resources/fixtures/api_spp_ignored_rules.json
+++ b/server/src/test/resources/fixtures/api_spp_ignored_rules.json
@@ -1,5 +1,5 @@
 {
-  "x-zally-ignore": ["166", "999"],
+  "x-zally-ignore": ["TCheckApiNameIsPresentJsonRule", "TCheckApiNameIsPresentRule"],
 
   "swagger": "2.0",
   "info": {


### PR DESCRIPTION
While working on #559 I hit problems due to having both a production rule 166 and separate test rule 166. Updated the test rules and rule ignoring tests so that they use distinct ids and a separate RuleSet for good measure.