### PR TITLE
Test rules have unique names and a distinct RuleSet (Replacement PR)

### DIFF
--- a/server/src/test/java/de/zalando/zally/apireview/RestApiIgnoreRulesTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiIgnoreRulesTest.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import static de.zalando.zally.util.ResourceUtil.readApiDefinition;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@TestPropertySource(properties = "zally.ignoreRules=H999")
+@TestPropertySource(properties = "zally.ignoreRules=TestAlwaysGiveAHintRule")
 public class RestApiIgnoreRulesTest extends RestApiBaseTest {
 
     @Test

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
@@ -1,25 +1,24 @@
 package de.zalando.zally.apireview;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import de.zalando.zally.rule.api.Severity;
 import de.zalando.zally.rule.AbstractRule;
 import de.zalando.zally.rule.ApiValidator;
 import de.zalando.zally.rule.CompositeRulesValidator;
 import de.zalando.zally.rule.JsonRulesValidator;
 import de.zalando.zally.rule.SwaggerRulesValidator;
-import de.zalando.zally.rule.api.Violation;
+import de.zalando.zally.rule.TestRuleSet;
 import de.zalando.zally.rule.api.Check;
 import de.zalando.zally.rule.api.Rule;
-import de.zalando.zally.rule.api.RuleSet;
+import de.zalando.zally.rule.api.Severity;
+import de.zalando.zally.rule.api.Violation;
 import de.zalando.zally.rule.zalando.InvalidApiSchemaRule;
-import de.zalando.zally.rule.zalando.ZalandoRuleSet;
 import io.swagger.models.Swagger;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,18 +35,20 @@ public class RestApiTestConfiguration {
     @Profile("test")
     public ApiValidator validator() {
         final List<Rule> rules = Arrays.asList(
-            new CheckApiNameIsPresentRule("Product Service"),
-            new AlwaysGiveAHintRule()
+            new TestCheckApiNameIsPresentJsonRule(),
+            new TestCheckApiNameIsPresentRule(),
+            new TestAlwaysGiveAHintRule()
         );
         return new CompositeRulesValidator(
                 new SwaggerRulesValidator(rules, invalidApiRule),
-                new JsonRulesValidator(Arrays.asList(new CheckApiNameIsPresentJsonRule(new ZalandoRuleSet())), invalidApiRule));
+                new JsonRulesValidator(rules, invalidApiRule));
     }
 
-    public static class CheckApiNameIsPresentJsonRule extends AbstractRule {
+    @Component
+    public static class TestCheckApiNameIsPresentJsonRule extends AbstractRule {
 
-        public CheckApiNameIsPresentJsonRule(@NotNull RuleSet ruleSet) {
-            super(ruleSet);
+        public TestCheckApiNameIsPresentJsonRule() {
+            super(new TestRuleSet());
         }
 
         @Check(severity = Severity.MUST)
@@ -68,7 +69,7 @@ public class RestApiTestConfiguration {
 
         @Override
         public String getId() {
-            return "166";
+            return getClass().getSimpleName();
         }
 
         @Override
@@ -77,18 +78,16 @@ public class RestApiTestConfiguration {
         }
     }
 
-    public static class CheckApiNameIsPresentRule extends AbstractRule {
+    @Component
+    public static class TestCheckApiNameIsPresentRule extends AbstractRule {
 
-        private final String apiName;
-
-        CheckApiNameIsPresentRule(String apiName) {
-            super(new ZalandoRuleSet());
-            this.apiName = apiName;
+        TestCheckApiNameIsPresentRule() {
+            super(new TestRuleSet());
         }
 
         @Check(severity = Severity.MUST)
         public Violation validate(Swagger swagger) {
-            if (swagger != null && swagger.getInfo().getTitle().contains(apiName)) {
+            if (swagger != null && swagger.getInfo().getTitle().contains("Product Service")) {
                 return new Violation("dummy", Collections.emptyList());
             } else {
                 return null;
@@ -102,19 +101,19 @@ public class RestApiTestConfiguration {
 
         @Override
         public String getId() {
-            return "999";
+            return getClass().getSimpleName();
         }
 
         @Override
         public Severity getSeverity() {
             return Severity.MUST;
         }
-
     }
 
-    public static class AlwaysGiveAHintRule extends AbstractRule {
-        public AlwaysGiveAHintRule() {
-            super(new ZalandoRuleSet());
+    @Component
+    public static class TestAlwaysGiveAHintRule extends AbstractRule {
+        public TestAlwaysGiveAHintRule() {
+            super(new TestRuleSet());
         }
 
         @Check(severity = Severity.HINT)
@@ -129,13 +128,12 @@ public class RestApiTestConfiguration {
 
         @Override
         public String getId() {
-            return "H999";
+            return getClass().getSimpleName();
         }
 
         @Override
         public Severity getSeverity() {
             return Severity.HINT;
         }
-
     }
 }

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
@@ -44,6 +44,7 @@ public class RestApiTestConfiguration {
                 new JsonRulesValidator(rules, invalidApiRule));
     }
 
+    /** Rule used for testing */
     @Component
     public static class TestCheckApiNameIsPresentJsonRule extends AbstractRule {
 
@@ -78,6 +79,7 @@ public class RestApiTestConfiguration {
         }
     }
 
+    /** Rule used for testing */
     @Component
     public static class TestCheckApiNameIsPresentRule extends AbstractRule {
 
@@ -110,6 +112,7 @@ public class RestApiTestConfiguration {
         }
     }
 
+    /** Rule used for testing */
     @Component
     public static class TestAlwaysGiveAHintRule extends AbstractRule {
         public TestAlwaysGiveAHintRule() {

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
@@ -101,7 +101,7 @@ public class RestApiViolationsTest extends RestApiBaseTest {
     @Test
     public void shouldIgnoreRulesWithApiParameter() throws IOException {
         ApiDefinitionRequest request = readApiDefinition("fixtures/api_spp.json");
-        request.setIgnoreRules(Arrays.asList("166", "999"));
+        request.setIgnoreRules(Arrays.asList("TestCheckApiNameIsPresentJsonRule", "TestCheckApiNameIsPresentRule"));
         ApiDefinitionResponse response = sendApiDefinition(request);
 
         List<ViolationDTO> violations = response.getViolations();

--- a/server/src/test/java/de/zalando/zally/rule/RulesPolicyTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesPolicyTest.kt
@@ -8,11 +8,14 @@ import io.swagger.models.Swagger
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.springframework.stereotype.Component
 
 class RulesPolicyTest {
+
+    @Component
     class TestRule(val result: Violation?) : AbstractRule(ZalandoRuleSet()) {
         override val title = "Test Rule"
-        override val id = "999"
+        override val id = javaClass.simpleName
         override val severity = Severity.MUST
 
         @Check(severity = Severity.MUST)
@@ -21,13 +24,13 @@ class RulesPolicyTest {
 
     @Test
     fun shouldAcceptRuleIfNotFiltered() {
-        val policy = RulesPolicy(arrayOf("166", "136"))
+        val policy = RulesPolicy(arrayOf("TestCheckApiNameIsPresentJsonRule", "136"))
         assertTrue(policy.accepts(TestRule(null)))
     }
 
     @Test
     fun shouldNotAcceptRuleIfFiltered() {
-        val policy = RulesPolicy(arrayOf("166", "999"))
+        val policy = RulesPolicy(arrayOf("TestCheckApiNameIsPresentJsonRule", "TestRule"))
         assertFalse(policy.accepts(TestRule(null)))
     }
 
@@ -36,7 +39,7 @@ class RulesPolicyTest {
         val original = RulesPolicy(emptyArray())
         assertTrue(original.accepts(TestRule(null)))
 
-        val extended = original.withMoreIgnores(listOf("166", "999"))
+        val extended = original.withMoreIgnores(listOf("TestCheckApiNameIsPresentJsonRule", "TestRule"))
         assertFalse(extended.accepts(TestRule(null)))
 
         // original is unmodified

--- a/server/src/test/java/de/zalando/zally/rule/RulesPolicyTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesPolicyTest.kt
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component
 
 class RulesPolicyTest {
 
+    /** TestRule used for testing RulesPolicy */
     @Component
     class TestRule(val result: Violation?) : AbstractRule(ZalandoRuleSet()) {
         override val title = "Test Rule"

--- a/server/src/test/java/de/zalando/zally/rule/TestRuleSet.java
+++ b/server/src/test/java/de/zalando/zally/rule/TestRuleSet.java
@@ -1,0 +1,36 @@
+package de.zalando.zally.rule;
+
+import de.zalando.zally.rule.api.Rule;
+import de.zalando.zally.rule.api.RuleSet;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+@Component
+public class TestRuleSet implements RuleSet {
+
+    @NotNull
+    @Override
+    public String getId() {
+        return getClass().getSimpleName();
+    }
+
+    @NotNull
+    @Override
+    public String getTitle() {
+        return "Test Rules";
+    }
+
+    @NotNull
+    @Override
+    public URI getUrl() {
+        return URI.create("http://test.example.com/");
+    }
+
+    @NotNull
+    @Override
+    public URI url(@NotNull Rule rule) {
+        return getUrl().resolve(rule.getId());
+    }
+}

--- a/server/src/test/java/de/zalando/zally/rule/TestRuleSet.java
+++ b/server/src/test/java/de/zalando/zally/rule/TestRuleSet.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import java.net.URI;
 
+/** RuleSet used to contain test rules */
 @Component
 public class TestRuleSet implements RuleSet {
 

--- a/server/src/test/resources/fixtures/api_spp_ignored_rules.json
+++ b/server/src/test/resources/fixtures/api_spp_ignored_rules.json
@@ -1,5 +1,5 @@
 {
-  "x-zally-ignore": ["166", "999"],
+  "x-zally-ignore": ["TestCheckApiNameIsPresentJsonRule", "TestCheckApiNameIsPresentRule"],
 
   "swagger": "2.0",
   "info": {


### PR DESCRIPTION
While working on #559 I hit problems due to having both a production rule 166 and separate test rule 166. Updated the test rules and rule ignoring tests so that they use distinct ids and a separate RuleSet for good measure.