### PR TITLE
cli/README.md: add src after GOPATH #625 

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -11,7 +11,7 @@ Just make sure that an issue describing the bug or feature does not already exis
 ## Pull Requests
 Follow these steps to contribute your work to Zally:
 
-1. [Open an issue](https://github.com/zalando/zally/issues) describing the problem or proposed feature. Ask maitainers (in the issue thread) to assign the issue to you so we know who is working on what.
+1. [Open an issue](https://github.com/zalando/zally/issues) describing the problem or proposed feature. Ask maintainers (in the issue thread) to assign the issue to you so we know who is working on what.
 1. Fork this repo and create a branch for your work.
 1. Push changes to your branch.
 1. Test your changes.

--- a/cli/README.md
+++ b/cli/README.md
@@ -8,12 +8,12 @@ requesting violations check at a given Zally server.
 
 1. Follow [Go installation instructions](https://golang.org/doc/install)
 
-1. Make sure that `$GOPATH` and `$GOROOT` variables are set
+1. Make sure that `$GOPATH` variable is set (and `$GOROOT` if necessary)
 
 1. Clone the repository:
 
     ```bash
-    git clone git@github.com:zalando/zally.git $GOPATH/github.com/zalando/zally
+    git clone git@github.com:zalando/zally.git $GOPATH/src/github.com/zalando/zally
     ```
 
 1. Install [golang/dep](https://github.com/golang/dep):
@@ -25,21 +25,21 @@ requesting violations check at a given Zally server.
 1. Get dependencies:
 
     ```bash
-    cd $GOPATH/github.com/zalando/zally/cli/zally
+    cd $GOPATH/src/github.com/zalando/zally/cli/zally
     dep ensure
     ```
 
 1. Run tests:
 
     ```bash
-    cd $GOPATH/github.com/zalando/zally/cli/zally
+    cd $GOPATH/src/github.com/zalando/zally/cli/zally
     ./test.sh
     ```
 
 1. Build the binary:
 
     ```bash
-    cd $GOPATH/github.com/zalando/zally/cli/zally
+    cd $GOPATH/src/github.com/zalando/zally/cli/zally
     go build
     ```
 


### PR DESCRIPTION
Zally should be cloned in `$GOPATH/src`, and not to `$GOPATH`, as per
golang/dep#911. Otherwise dep won't work:

```
$ cd $GOPATH/github.com/zalando/zally/cli/zally/
$ dep ensure
root project import: $GOPATH/github.com/zalando/zally/cli/zally is not within any GOPATH/src
```

where as `$GOPATH/src/github.com/zalando/zally/cli/zally` does work with dep.

Related to #625.