### PR TITLE
Validate HTTP response when retrieving a definition from a url

### DIFF
--- a/cli/zally/integration_test.go
+++ b/cli/zally/integration_test.go
@@ -135,11 +135,13 @@ func TestIntegrationWithZallyApiDefinition(t *testing.T) {
 	t.Run("integrationWithZallyApiDefinition", func(t *testing.T) {
 		out, e := RunAppAndCaptureOutput([]string{"", "lint", "../../server/src/main/resources/api/zally-api.yaml"})
 
-		assert.Contains(t, out, "[33mSHOULD[0m [33mUse Specific HTTP Status Codes[0m")
+		assert.Contains(t, out, "[33mSHOULD[0m [33mUse Specific HTTP Status Codes[0m")
+		assert.Contains(t, out, "[36mHINT[0m [36mNot Specify Standard Error Codes[0m")
+
 		assert.Contains(t, out, "MUST violations: 0")
 		assert.Contains(t, out, "SHOULD violations: 1")
 		assert.Contains(t, out, "MAY violations: 0")
-		assert.Contains(t, out, "HINT violations: 0")
+		assert.Contains(t, out, "HINT violations: 1")
 
 		assert.Nil(t, e)
 	})
@@ -149,7 +151,7 @@ func TestIntegrationDisplayRulesList(t *testing.T) {
 	t.Run("integrationDisplayRulesList", func(t *testing.T) {
 		out, e := RunAppAndCaptureOutput([]string{"", "rules"})
 
-		assert.Contains(t, out, "[31m166[0m [31mMUST[0m: Avoid Link in Header Rule")
+		assert.Contains(t, out, "[31m166[0m [31mMUST[0m: Avoid Link in Header Rule")
 		assert.Contains(t, out, "https://zalando.github.io/restful-api-guidelines/#166")
 
 		assert.Nil(t, e)

--- a/server/src/main/java/de/zalando/zally/apireview/ApiDefinitionReader.java
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiDefinitionReader.java
@@ -13,11 +13,8 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
-import java.util.stream.Stream;
 
-import static java.lang.String.format;
 import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.MediaType.parseMediaTypes;
 
@@ -29,6 +26,7 @@ public class ApiDefinitionReader {
 
     // a whitelist of mime-types to accept when expecting JSON or YAML
     private static final List<MediaType> MEDIA_TYPE_WHITELIST = parseMediaTypes(asList(
+        // standard YAML mime-type plus variants
         "application/yaml",
         "application/x-yaml",
         "application/vnd.yaml",
@@ -36,12 +34,14 @@ public class ApiDefinitionReader {
         "text/x-yaml",
         "text/vnd.yaml",
 
+        // standard JSON mime-type plus variants
         "application/json",
         "application/javascript",
         "text/javascript",
         "text/x-javascript",
         "text/x-json",
 
+        // github.com raw content pages issue text/plain content type for YAML
         "text/plain"
     ));
 

--- a/server/src/main/java/de/zalando/zally/apireview/ApiDefinitionReader.java
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiDefinitionReader.java
@@ -5,16 +5,45 @@ import de.zalando.zally.exception.MissingApiDefinitionException;
 import de.zalando.zally.exception.UnaccessibleResourceUrlException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.MediaType.parseMediaTypes;
 
 @Component
 public class ApiDefinitionReader {
 
     // some internal systems add these characters at the end of some urls, don't know why
     private static final String SPECIAL_CHARACTERS_SUFFIX = "%3D%3D";
+
+    // a whitelist of mime-types to accept when expecting JSON or YAML
+    private static final List<MediaType> MEDIA_TYPE_WHITELIST = parseMediaTypes(asList(
+        "application/yaml",
+        "application/x-yaml",
+        "application/vnd.yaml",
+        "text/yaml",
+        "text/x-yaml",
+        "text/vnd.yaml",
+
+        "application/json",
+        "application/javascript",
+        "text/javascript",
+        "text/x-javascript",
+        "text/x-json",
+
+        "text/plain"
+    ));
 
     private final RestTemplate client;
 
@@ -35,7 +64,19 @@ public class ApiDefinitionReader {
 
     private String readFromUrl(String url) throws UnaccessibleResourceUrlException {
         try {
-            return client.getForEntity(removeSpecialCharactersSuffix(url), String.class).getBody();
+            final ResponseEntity<String> response = client.getForEntity(removeSpecialCharactersSuffix(url), String.class);
+
+            final HttpStatus status = response.getStatusCode();
+            if (!status.is2xxSuccessful()) {
+                throw new UnaccessibleResourceUrlException("Unexpected response " + status.value() + " " + status.getReasonPhrase(), BAD_REQUEST);
+            }
+
+            final MediaType contentType = response.getHeaders().getContentType();
+            if (MEDIA_TYPE_WHITELIST.stream().noneMatch(contentType::isCompatibleWith)) {
+                throw new UnaccessibleResourceUrlException("Unexpected content type in response: " + contentType, BAD_REQUEST);
+            }
+
+            return response.getBody();
         } catch (HttpClientErrorException exception) {
             throw new UnaccessibleResourceUrlException(exception.getMessage(), exception.getStatusCode());
         } catch (ResourceAccessException exception) {

--- a/server/src/main/resources/api/zally-api.yaml
+++ b/server/src/main/resources/api/zally-api.yaml
@@ -3,7 +3,7 @@ swagger: '2.0'
 info:
  title: Zally
  description: Zalando's API Linter
- version: "1.1.1"
+ version: "1.2.0"
  contact:
    name: Team API Management
    email: team-api-management@zalando.de

--- a/server/src/main/resources/api/zally-api.yaml
+++ b/server/src/main/resources/api/zally-api.yaml
@@ -79,8 +79,15 @@ paths:
       description: |
         The API Violations endpoint validates given Swagger Specification
         against the rules defined in *Zalando* RESTful API Guidelines
-        (http://zalando.github.io/restful-api-guidelines/). The response
-        includes the list of violations grouped by the API Guidelines rules.
+        (http://zalando.github.io/restful-api-guidelines/).
+
+        A successful response includes the list of violations grouped by
+        the API Guidelines rules.
+
+        If an api definition is supplied via url then any non-successful
+        responses from that will be passed on. For example you may be
+        using Zally without authentication but supply a password
+        protected url and still get a `401 Unauthorized` response.
       parameters:
         - $ref: '#/parameters/Authorization'
         - $ref: '#/parameters/LintingRequest'
@@ -95,6 +102,10 @@ paths:
             $ref: '#/definitions/LintingResponse'
         400:
           description: Input file not parsable
+          schema:
+            $ref: 'https://zalando.github.io/problem/schema.yaml#/Problem'
+        415:
+          description: API definition url responded with content-type which clearly isn't JSON or YAML.
           schema:
             $ref: 'https://zalando.github.io/problem/schema.yaml#/Problem'
         default:

--- a/server/src/test/java/de/zalando/zally/apireview/ApiDefinitionReaderTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiDefinitionReaderTest.java
@@ -2,17 +2,21 @@ package de.zalando.zally.apireview;
 
 import de.zalando.zally.dto.ApiDefinitionRequest;
 import de.zalando.zally.exception.MissingApiDefinitionException;
+import de.zalando.zally.exception.UnaccessibleResourceUrlException;
 import de.zalando.zally.util.JadlerUtil;
 import net.jadler.stubbing.server.jdk.JdkStubHttpServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.client.RestTemplate;
 
 import static java.util.Collections.emptyList;
 import static net.jadler.Jadler.closeJadler;
 import static net.jadler.Jadler.initJadlerUsing;
 import static org.junit.Assert.assertEquals;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.TEXT_HTML_VALUE;
 
 public class ApiDefinitionReaderTest {
 
@@ -66,5 +70,20 @@ public class ApiDefinitionReaderTest {
         String url = JadlerUtil.stubResource("test.json", contentInJson);
         String result = reader.read(ApiDefinitionRequest.Factory.fromUrl(url + "%3D%3D"));
         assertEquals(contentInJson, result);
+    }
+
+    @Test(expected = UnaccessibleResourceUrlException.class)
+    public void shouldErrorBadRequestWhenDefinitionFromUrlUnsuccessful() {
+        final int status = HttpStatus.UNAUTHORIZED.value();
+        String url = JadlerUtil.stubResource("test.json", "", status, APPLICATION_JSON_VALUE);
+
+        reader.read(ApiDefinitionRequest.Factory.fromUrl(url));
+    }
+
+    @Test(expected = UnaccessibleResourceUrlException.class)
+    public void shouldErrorBadRequestWhenDefinitionFromUrlWrongContentType() {
+        String url = JadlerUtil.stubResource("test.json", "", HttpStatus.OK.value(), TEXT_HTML_VALUE);
+
+        reader.read(ApiDefinitionRequest.Factory.fromUrl(url));
     }
 }

--- a/server/src/test/java/de/zalando/zally/apireview/ApiDefinitionReaderTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiDefinitionReaderTest.java
@@ -74,8 +74,7 @@ public class ApiDefinitionReaderTest {
 
     @Test(expected = UnaccessibleResourceUrlException.class)
     public void shouldErrorBadRequestWhenDefinitionFromUrlUnsuccessful() {
-        final int status = HttpStatus.UNAUTHORIZED.value();
-        String url = JadlerUtil.stubResource("test.json", "", status, APPLICATION_JSON_VALUE);
+        String url = JadlerUtil.stubResource("test.json", "", HttpStatus.UNAUTHORIZED.value(), APPLICATION_JSON_VALUE);
 
         reader.read(ApiDefinitionRequest.Factory.fromUrl(url));
     }

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
@@ -179,7 +179,7 @@ public class RestApiViolationsTest extends RestApiBaseTest {
         );
 
         assertThat(responseEntity.getStatusCode()).isEqualTo(NOT_FOUND);
-        assertThat(responseEntity.getBody().getDetail()).isEqualTo("Unknown host: remote-localhost");
+        assertThat(responseEntity.getBody().getDetail()).isEqualTo("Unknown host while retrieving api definition url: remote-localhost");
     }
 
     @Test
@@ -190,7 +190,7 @@ public class RestApiViolationsTest extends RestApiBaseTest {
         );
 
         assertThat(responseEntity.getStatusCode()).isEqualTo(NOT_FOUND);
-        assertThat(responseEntity.getBody().getDetail()).isEqualTo("404 Not Found");
+        assertThat(responseEntity.getBody().getDetail()).isEqualTo("404 Not Found while retrieving api definition url");
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/util/JadlerUtil.java
+++ b/server/src/test/java/de/zalando/zally/util/JadlerUtil.java
@@ -23,13 +23,17 @@ public class JadlerUtil {
     }
 
     public static String stubResource(String resourceName, String responseBody, String contentType) {
+        return stubResource(resourceName, responseBody, OK.value(), contentType);
+    }
+
+    public static String stubResource(String resourceName, String responseBody, int status, String contentType) {
         String url = String.format("http://localhost:%d/%s", port(), resourceName);
 
         onRequest()
             .havingMethodEqualTo(GET.name())
             .havingPathEqualTo("/" + resourceName)
             .respond()
-            .withStatus(OK.value())
+            .withStatus(status)
             .withHeader(CONTENT_TYPE, contentType)
             .withBody(responseBody);
 


### PR DESCRIPTION
When retrieving a users API definition from a url we now:
* Verify that the response was in the HTTP 2xx success family.
* Verify that the response has a JSON or YAML looking Content-Type.

Failing either verification results in an error in the UI and avoids processing against validation rules.

Addresses #640.