### PR TITLE
553: API Title Must be Set

### DIFF
--- a/cli/zally/integration_test.go
+++ b/cli/zally/integration_test.go
@@ -64,7 +64,7 @@ func TestIntegrationWithSomeOtherLocalYamlFile(t *testing.T) {
 	t.Run("integrationWithSomeOtherLocalYamlFile", func(t *testing.T) {
 		out, e := RunAppAndCaptureOutput([]string{"", "lint", "../../server/src/test/resources/fixtures/api_tinbox.yaml"})
 
-		assert.Contains(t, out, "OpenAPI 2.0 schema")
+		assert.Contains(t, out, "Provide API Specification using OpenAPI")
 		assert.Contains(t, out, "MUST violations: 9")
 		assert.Contains(t, out, "SHOULD violations: 3")
 		assert.Contains(t, out, "MAY violations: 0")

--- a/server/src/main/java/de/zalando/zally/rule/JsonRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonRulesValidator.kt
@@ -1,13 +1,13 @@
 package de.zalando.zally.rule
 
 import com.fasterxml.jackson.databind.JsonNode
-import de.zalando.zally.rule.zalando.InvalidApiSchemaRule
+import de.zalando.zally.rule.zalando.UseOpenApiRule
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
 class JsonRulesValidator(@Autowired rules: RulesManager,
-                         @Autowired invalidApiRule: InvalidApiSchemaRule) : RulesValidator<JsonNode>(rules, invalidApiRule) {
+                         @Autowired useOpenApiRule: UseOpenApiRule) : RulesValidator<JsonNode>(rules, useOpenApiRule) {
 
     private val reader = ObjectTreeReader()
 

--- a/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
@@ -1,10 +1,10 @@
 package de.zalando.zally.rule
 
 import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.rule.zalando.InvalidApiSchemaRule
+import de.zalando.zally.rule.zalando.UseOpenApiRule
 import org.slf4j.LoggerFactory
 
-abstract class RulesValidator<RootT>(val rules: RulesManager, private val invalidApiRule: InvalidApiSchemaRule) : ApiValidator {
+abstract class RulesValidator<RootT>(val rules: RulesManager, private val useOpenApiRule: UseOpenApiRule) : ApiValidator {
 
     private val log = LoggerFactory.getLogger(RulesValidator::class.java)
 
@@ -13,7 +13,7 @@ abstract class RulesValidator<RootT>(val rules: RulesManager, private val invali
     val zallyIgnoreExtension = "x-zally-ignore"
 
     final override fun validate(content: String, requestPolicy: RulesPolicy): List<Result> {
-        val root = parse(content) ?: return listOf(invalidApiRule.getGeneralViolation())
+        val root = parse(content) ?: return listOf(useOpenApiRule.getGeneralViolation())
 
         val moreIgnores = ignores(root)
         log.debug("ignoring $moreIgnores from document as well as ${requestPolicy.ignoreRules}")

--- a/server/src/main/java/de/zalando/zally/rule/SwaggerRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SwaggerRulesValidator.kt
@@ -1,6 +1,6 @@
 package de.zalando.zally.rule
 
-import de.zalando.zally.rule.zalando.InvalidApiSchemaRule
+import de.zalando.zally.rule.zalando.UseOpenApiRule
 import io.swagger.models.Swagger
 import io.swagger.parser.SwaggerParser
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 class SwaggerRulesValidator(@Autowired rules: RulesManager,
-                            @Autowired invalidApiRule: InvalidApiSchemaRule) : RulesValidator<Swagger>(rules, invalidApiRule) {
+                            @Autowired useOpenApiRule: UseOpenApiRule) : RulesValidator<Swagger>(rules, useOpenApiRule) {
 
     override fun parse(content: String): Swagger? {
         return try {

--- a/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
@@ -20,11 +20,11 @@ import java.net.URL
         ruleSet = ZalandoRuleSet::class,
         id = "101",
         severity = Severity.MUST,
-        title = "OpenAPI 2.0 schema"
+        title = "Provide API Specification using OpenAPI"
 )
-open class InvalidApiSchemaRule(@Autowired rulesConfig: Config) {
+open class UseOpenApiRule(@Autowired rulesConfig: Config) {
 
-    private val log = LoggerFactory.getLogger(InvalidApiSchemaRule::class.java)
+    private val log = LoggerFactory.getLogger(UseOpenApiRule::class.java)
 
     open val description = "Given file is not OpenAPI 2.0 compliant."
 

--- a/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
@@ -34,6 +34,15 @@ open class UseOpenApiRule(@Autowired rulesConfig: Config) {
         jsonSchemaValidator = getSchemaValidator(rulesConfig.getConfig(javaClass.simpleName))
     }
 
+    @Check(severity = Severity.MUST)
+    fun validate(swagger: JsonNode): List<Violation> {
+        return jsonSchemaValidator.validate(swagger).let { validationResult ->
+            validationResult.messages.map { message ->
+                Violation(message.message, listOf(message.path))
+            }
+        }
+    }
+
     private fun getSchemaValidator(ruleConfig: Config): JsonSchemaValidator {
         val schemaUrlProperty = "swagger_schema_url"
         if (!ruleConfig.hasPath(schemaUrlProperty)) {
@@ -58,15 +67,6 @@ open class UseOpenApiRule(@Autowired rulesConfig: Config) {
         val schemaUrl = Resources.getResource("schemas/swagger-schema.json")
         val schema = ObjectTreeReader().readJson(schemaUrl)
         return JsonSchemaValidator(schema, schemaRedirects = mapOf(referencedOnlineSchema to localResource))
-    }
-
-    @Check(severity = Severity.MUST)
-    fun validate(swagger: JsonNode): List<Violation> {
-        return jsonSchemaValidator.validate(swagger).let { validationResult ->
-            validationResult.messages.map { message ->
-                Violation(message.message, listOf(message.path))
-            }
-        }
     }
 
     fun getGeneralViolation(): Result =

--- a/server/src/main/resources/rules-config.conf
+++ b/server/src/main/resources/rules-config.conf
@@ -60,7 +60,7 @@ NotSpecifyStandardErrorCodesRule {
   standard_error_codes: [401, 403, 404, 405, 406, 408, 413, 414, 415, 500, 502, 503, 504]
 }
 
-InvalidApiSchemaRule {
+UseOpenApiRule {
   swagger_schema_url: "http://swagger.io/v2/schema.json"
 }
 

--- a/server/src/test/java/de/zalando/zally/apireview/ApiReviewTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiReviewTest.java
@@ -5,7 +5,7 @@ import de.zalando.zally.rule.Result;
 import de.zalando.zally.rule.TestRuleSet;
 import de.zalando.zally.rule.api.Severity;
 import de.zalando.zally.rule.api.Rule;
-import de.zalando.zally.rule.zalando.InvalidApiSchemaRule;
+import de.zalando.zally.rule.zalando.UseOpenApiRule;
 import de.zalando.zally.util.ResourceUtil;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -54,6 +54,6 @@ public class ApiReviewTest {
 
     @NotNull
     private Result result(Severity severity, List<String> paths) {
-        return new Result(new TestRuleSet(), InvalidApiSchemaRule.class.getAnnotation(Rule.class), "", severity, paths);
+        return new Result(new TestRuleSet(), UseOpenApiRule.class.getAnnotation(Rule.class), "", severity, paths);
     }
 }

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
@@ -6,7 +6,7 @@ import de.zalando.zally.rule.api.Check;
 import de.zalando.zally.rule.api.Rule;
 import de.zalando.zally.rule.api.Severity;
 import de.zalando.zally.rule.api.Violation;
-import de.zalando.zally.rule.zalando.InvalidApiSchemaRule;
+import de.zalando.zally.rule.zalando.UseOpenApiRule;
 import io.swagger.models.Swagger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -22,7 +22,7 @@ import java.util.Collections;
 public class RestApiTestConfiguration {
 
     @Autowired
-    private InvalidApiSchemaRule invalidApiRule;
+    private UseOpenApiRule invalidApiRule;
 
     @Bean
     @Primary

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
@@ -143,7 +143,7 @@ public class RestApiViolationsTest extends RestApiBaseTest {
         );
 
         assertThat(response.getViolations()).hasSize(1);
-        assertThat(response.getViolations().get(0).getTitle()).isEqualTo("OpenAPI 2.0 schema");
+        assertThat(response.getViolations().get(0).getTitle()).isEqualTo("Provide API Specification using OpenAPI");
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
@@ -5,7 +5,7 @@ import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.rule.zalando.InvalidApiSchemaRule
+import de.zalando.zally.rule.zalando.UseOpenApiRule
 import io.swagger.models.Swagger
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -63,12 +63,12 @@ class RulesValidatorTest {
         fun invalidParams(swagger: Swagger, json: JsonNode): Violation? = null
     }
 
-    val invalidApiSchemaRule: InvalidApiSchemaRule = mock(InvalidApiSchemaRule::class.java)
+    val useOpenApiRule: UseOpenApiRule = mock(UseOpenApiRule::class.java)
 
     @Test
     fun shouldReturnEmptyViolationsListWithoutRules() {
         val rules = emptyList<Any>()
-        val validator = SwaggerRulesValidator(rulesManager(rules), invalidApiSchemaRule)
+        val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
         assertThat(results)
                 .isEmpty()
@@ -77,7 +77,7 @@ class RulesValidatorTest {
     @Test
     fun shouldReturnOneViolation() {
         val rules = listOf(TestSecondRule())
-        val validator = SwaggerRulesValidator(rulesManager(rules), invalidApiSchemaRule)
+        val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
         assertThat(results.map(Result::toViolation).map(Violation::description))
                 .containsExactly("dummy3")
@@ -86,7 +86,7 @@ class RulesValidatorTest {
     @Test
     fun shouldCollectViolationsOfAllRules() {
         val rules = listOf(TestFirstRule())
-        val validator = SwaggerRulesValidator(rulesManager(rules), invalidApiSchemaRule)
+        val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
         assertThat(results.map(Result::toViolation).map(Violation::description))
                 .containsExactly("dummy1", "dummy2")
@@ -95,7 +95,7 @@ class RulesValidatorTest {
     @Test
     fun shouldSortViolationsByViolationType() {
         val rules = listOf(TestFirstRule(), TestSecondRule())
-        val validator = SwaggerRulesValidator(rulesManager(rules), invalidApiSchemaRule)
+        val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
         assertThat(results.map(Result::toViolation).map(Violation::description))
                 .containsExactly("dummy3", "dummy1", "dummy2")
@@ -104,7 +104,7 @@ class RulesValidatorTest {
     @Test
     fun shouldIgnoreSpecifiedRules() {
         val rules = listOf(TestFirstRule(), TestSecondRule())
-        val validator = SwaggerRulesValidator(rulesManager(rules), invalidApiSchemaRule)
+        val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
         val results = validator.validate(swaggerContent, RulesPolicy(arrayOf("TestSecondRule")))
         assertThat(results.map(Result::toViolation).map(Violation::description))
                 .containsExactly("dummy1", "dummy2")
@@ -114,7 +114,7 @@ class RulesValidatorTest {
     fun checkReturnsStringThrowsException() {
         val rules = listOf(TestBadRule())
         assertThatThrownBy {
-            val validator = SwaggerRulesValidator(rulesManager(rules), invalidApiSchemaRule)
+            val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
             validator.validate(swaggerContent, RulesPolicy(arrayOf("TestCheckApiNameIsPresentRule")))
         }.hasMessage("Unsupported return type for a @Check method!: class java.lang.String")
     }

--- a/server/src/test/java/de/zalando/zally/rule/zalando/UseOpenApiRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/UseOpenApiRuleTest.kt
@@ -6,9 +6,9 @@ import de.zalando.zally.testConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
-class InvalidApiSchemaRuleTest {
+class UseOpenApiRuleTest {
 
-    private val rule = InvalidApiSchemaRule(testConfig)
+    private val rule = UseOpenApiRule(testConfig)
 
     @Test
     fun shouldNotFailOnCorrectYaml() {
@@ -62,13 +62,13 @@ class InvalidApiSchemaRuleTest {
     @Test
     fun shouldLoadSchemaFromResourceIfUrlNotSpecified() {
         val config = ConfigFactory.parseString("""
-        InvalidApiSchemaRule {
+        UseOpenApiRule {
              // swagger_schema_url not defined
         }
         """)
 
         val swaggerJson = getResourceJson("common_fields_invalid.yaml")
-        val validations = InvalidApiSchemaRule(config).validate(swaggerJson)
+        val validations = UseOpenApiRule(config).validate(swaggerJson)
         assertThat(validations).hasSize(1)
         assertThat(validations[0].description).isEqualTo("""object has missing required properties (["paths"])""")
     }
@@ -76,13 +76,13 @@ class InvalidApiSchemaRuleTest {
     @Test
     fun shouldLoadSchemaFromResourceIfLoadFromUrlFailed() {
         val config = ConfigFactory.parseString("""
-        InvalidApiSchemaRule {
+        UseOpenApiRule {
              swagger_schema_url: "http://localhost/random_url.html"
         }
         """)
 
         val swaggerJson = getResourceJson("common_fields_invalid.yaml")
-        val validations = InvalidApiSchemaRule(config).validate(swaggerJson)
+        val validations = UseOpenApiRule(config).validate(swaggerJson)
         assertThat(validations).hasSize(1)
         assertThat(validations[0].description).isEqualTo("""object has missing required properties (["paths"])""")
     }

--- a/server/src/test/java/de/zalando/zally/rule/zalando/UseOpenApiRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/UseOpenApiRuleTest.kt
@@ -86,4 +86,12 @@ class UseOpenApiRuleTest {
         assertThat(validations).hasSize(1)
         assertThat(validations[0].description).isEqualTo("""object has missing required properties (["paths"])""")
     }
+
+    @Test
+    fun shouldCheckApiTitle() {
+        val swagger = getResourceJson("no_title.yaml")
+        val violations = rule.validate(swagger)
+        assertThat(violations).hasSize(1)
+        assertThat(violations[0].description).isEqualTo("object has missing required properties ([\"title\"])")
+    }
 }

--- a/server/src/test/resources/fixtures/no_title.yaml
+++ b/server/src/test/resources/fixtures/no_title.yaml
@@ -1,0 +1,14 @@
+swagger: "2.0"
+info:
+  description: Test Description
+  version: "1.0.0"
+  contact:
+    name: John Smith
+    email: smith@example.com
+paths:
+  /articles:
+    get:
+      summary: returns list of articles
+      responses:
+        200:
+          description: Success


### PR DESCRIPTION
Closes #553 

Provides only some refactoring. Found out that API title is already checked as a part of OpenAPI Specification check. 