### PR TITLE
UseOpenApiRule is not treated specially

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/JsonRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonRulesValidator.kt
@@ -1,13 +1,11 @@
 package de.zalando.zally.rule
 
 import com.fasterxml.jackson.databind.JsonNode
-import de.zalando.zally.rule.zalando.UseOpenApiRule
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class JsonRulesValidator(@Autowired rules: RulesManager,
-                         @Autowired useOpenApiRule: UseOpenApiRule) : RulesValidator<JsonNode>(rules, useOpenApiRule) {
+class JsonRulesValidator(@Autowired rules: RulesManager) : RulesValidator<JsonNode>(rules) {
 
     private val reader = ObjectTreeReader()
 

--- a/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
@@ -1,10 +1,9 @@
 package de.zalando.zally.rule
 
 import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.rule.zalando.UseOpenApiRule
 import org.slf4j.LoggerFactory
 
-abstract class RulesValidator<RootT>(val rules: RulesManager, private val useOpenApiRule: UseOpenApiRule) : ApiValidator {
+abstract class RulesValidator<RootT>(val rules: RulesManager) : ApiValidator {
 
     private val log = LoggerFactory.getLogger(RulesValidator::class.java)
 
@@ -13,7 +12,7 @@ abstract class RulesValidator<RootT>(val rules: RulesManager, private val useOpe
     val zallyIgnoreExtension = "x-zally-ignore"
 
     final override fun validate(content: String, requestPolicy: RulesPolicy): List<Result> {
-        val root = parse(content) ?: return listOf(useOpenApiRule.getGeneralViolation())
+        val root = parse(content) ?: return emptyList()
 
         val moreIgnores = ignores(root)
         log.debug("ignoring $moreIgnores from document as well as ${requestPolicy.ignoreRules}")

--- a/server/src/main/java/de/zalando/zally/rule/SwaggerRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SwaggerRulesValidator.kt
@@ -1,6 +1,5 @@
 package de.zalando.zally.rule
 
-import de.zalando.zally.rule.zalando.UseOpenApiRule
 import io.swagger.models.Swagger
 import io.swagger.parser.SwaggerParser
 import org.springframework.beans.factory.annotation.Autowired
@@ -11,8 +10,7 @@ import org.springframework.stereotype.Component
  * on set of rules. It will sort the output by path.
  */
 @Component
-class SwaggerRulesValidator(@Autowired rules: RulesManager,
-                            @Autowired useOpenApiRule: UseOpenApiRule) : RulesValidator<Swagger>(rules, useOpenApiRule) {
+class SwaggerRulesValidator(@Autowired rules: RulesManager) : RulesValidator<Swagger>(rules) {
 
     override fun parse(content: String): Swagger? {
         return try {

--- a/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
@@ -6,7 +6,6 @@ import com.google.common.io.Resources
 import com.typesafe.config.Config
 import de.zalando.zally.rule.JsonSchemaValidator
 import de.zalando.zally.rule.ObjectTreeReader
-import de.zalando.zally.rule.Result
 import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
@@ -68,7 +67,4 @@ open class UseOpenApiRule(@Autowired rulesConfig: Config) {
         val schema = ObjectTreeReader().readJson(schemaUrl)
         return JsonSchemaValidator(schema, schemaRedirects = mapOf(referencedOnlineSchema to localResource))
     }
-
-    fun getGeneralViolation(): Result =
-            Result(ZalandoRuleSet(), this.javaClass.getAnnotation(Rule::class.java), description, Severity.MUST, emptyList())
 }

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
@@ -31,7 +31,8 @@ public class RestApiTestConfiguration {
         return Arrays.asList(
                 new TestCheckApiNameIsPresentJsonRule(),
                 new TestCheckApiNameIsPresentRule(),
-                new TestAlwaysGiveAHintRule()
+                new TestAlwaysGiveAHintRule(),
+                invalidApiRule
         );
     }
 

--- a/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
@@ -5,12 +5,10 @@ import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.rule.zalando.UseOpenApiRule
 import io.swagger.models.Swagger
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
-import org.mockito.Mockito.mock
 import kotlin.reflect.full.createInstance
 
 class RulesValidatorTest {
@@ -63,12 +61,10 @@ class RulesValidatorTest {
         fun invalidParams(swagger: Swagger, json: JsonNode): Violation? = null
     }
 
-    val useOpenApiRule: UseOpenApiRule = mock(UseOpenApiRule::class.java)
-
     @Test
     fun shouldReturnEmptyViolationsListWithoutRules() {
         val rules = emptyList<Any>()
-        val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
+        val validator = SwaggerRulesValidator(rulesManager(rules))
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
         assertThat(results)
                 .isEmpty()
@@ -77,7 +73,7 @@ class RulesValidatorTest {
     @Test
     fun shouldReturnOneViolation() {
         val rules = listOf(TestSecondRule())
-        val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
+        val validator = SwaggerRulesValidator(rulesManager(rules))
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
         assertThat(results.map(Result::toViolation).map(Violation::description))
                 .containsExactly("dummy3")
@@ -86,7 +82,7 @@ class RulesValidatorTest {
     @Test
     fun shouldCollectViolationsOfAllRules() {
         val rules = listOf(TestFirstRule())
-        val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
+        val validator = SwaggerRulesValidator(rulesManager(rules))
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
         assertThat(results.map(Result::toViolation).map(Violation::description))
                 .containsExactly("dummy1", "dummy2")
@@ -95,7 +91,7 @@ class RulesValidatorTest {
     @Test
     fun shouldSortViolationsByViolationType() {
         val rules = listOf(TestFirstRule(), TestSecondRule())
-        val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
+        val validator = SwaggerRulesValidator(rulesManager(rules))
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
         assertThat(results.map(Result::toViolation).map(Violation::description))
                 .containsExactly("dummy3", "dummy1", "dummy2")
@@ -104,7 +100,7 @@ class RulesValidatorTest {
     @Test
     fun shouldIgnoreSpecifiedRules() {
         val rules = listOf(TestFirstRule(), TestSecondRule())
-        val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
+        val validator = SwaggerRulesValidator(rulesManager(rules))
         val results = validator.validate(swaggerContent, RulesPolicy(arrayOf("TestSecondRule")))
         assertThat(results.map(Result::toViolation).map(Violation::description))
                 .containsExactly("dummy1", "dummy2")
@@ -114,7 +110,7 @@ class RulesValidatorTest {
     fun checkReturnsStringThrowsException() {
         val rules = listOf(TestBadRule())
         assertThatThrownBy {
-            val validator = SwaggerRulesValidator(rulesManager(rules), useOpenApiRule)
+            val validator = SwaggerRulesValidator(rulesManager(rules))
             validator.validate(swaggerContent, RulesPolicy(arrayOf("TestCheckApiNameIsPresentRule")))
         }.hasMessage("Unsupported return type for a @Check method!: class java.lang.String")
     }


### PR DESCRIPTION
As long as `UseOpenApiRule` is in the active list of rules then `UseOpenApiRule.getGeneralViolation()` can be removed.

Addresses #645.