### PR TITLE
Moved shared HttpHeadersRule code to core package

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/HttpHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/HttpHeadersRule.kt
@@ -1,4 +1,4 @@
-package de.zalando.zally.rule.zalando
+package de.zalando.zally.rule
 
 import com.typesafe.config.Config
 import de.zalando.zally.rule.api.Violation

--- a/server/src/main/java/de/zalando/zally/rule/zalando/AvoidLinkHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/AvoidLinkHeadersRule.kt
@@ -1,6 +1,7 @@
 package de.zalando.zally.rule.zalando
 
 import com.typesafe.config.Config
+import de.zalando.zally.rule.HttpHeadersRule
 import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation

--- a/server/src/main/java/de/zalando/zally/rule/zalando/PascalCaseHttpHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/PascalCaseHttpHeadersRule.kt
@@ -1,6 +1,7 @@
 package de.zalando.zally.rule.zalando
 
 import com.typesafe.config.Config
+import de.zalando.zally.rule.HttpHeadersRule
 import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation

--- a/server/src/main/java/de/zalando/zally/rule/zally/HyphenateHttpHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/HyphenateHttpHeadersRule.kt
@@ -5,7 +5,7 @@ import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
 import de.zalando.zally.rule.api.Rule
-import de.zalando.zally.rule.zalando.HttpHeadersRule
+import de.zalando.zally.rule.HttpHeadersRule
 import de.zalando.zally.util.PatternUtil
 import io.swagger.models.Swagger
 import org.springframework.beans.factory.annotation.Autowired


### PR DESCRIPTION
Moved shared `HttpHeadersRule` code to core package used by both zally and zalando sub-packages, rather than have a dependency between the ruleset sub-packages.

Tidying up package dependencies ahead of #560. 