### PR TITLE
Checks can now process x-zally-ignore against arbitrary locations in the definition

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/SwaggerIgnoreExtension.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SwaggerIgnoreExtension.kt
@@ -1,0 +1,20 @@
+package de.zalando.zally.rule
+
+/**
+ * Implements x-zally-ignore checking functionality for use at arbitrary
+ * vendorExtensions throughout the API specification.
+ *
+ * @param ruleId the id of the currently running rule
+ */
+class SwaggerIgnoreExtension(private val ruleId: String) {
+
+    /**
+     * Asserts that vendor extension allows this rule to run.
+     * @param vendorExtensions the x- prefixed extensions being checked.
+     * @return true if x-zally-ignore extension is missing or does not specify the current rule.
+     */
+    fun accepts(vendorExtensions: Map<String, Any>?): Boolean {
+        val ignores = vendorExtensions?.get("x-zally-ignore")
+        return if (ignores is Iterable<*>) !ignores.contains(ruleId) else true
+    }
+}

--- a/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
@@ -40,7 +40,7 @@ class RulesValidatorTest {
 
         @Suppress("UNUSED_PARAMETER")
         @Check(severity = Severity.MUST)
-        fun validate(swagger: Swagger): Violation? =
+        fun validate(swagger: Swagger, ignore: SwaggerIgnoreExtension): Violation? =
                 Violation("dummy3", listOf("a"))
     }
 
@@ -58,7 +58,7 @@ class RulesValidatorTest {
 
         @Suppress("UNUSED_PARAMETER")
         @Check(severity = Severity.MUST)
-        fun invalidParams(swagger: Swagger, json: JsonNode): Violation? = null
+        fun invalidParams(swagger: Swagger, json: JsonNode, text: String): Violation? = null
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/zalando/LimitNumberOfSubresourcesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/LimitNumberOfSubresourcesRuleTest.kt
@@ -21,8 +21,8 @@ class LimitNumberOfSubresourcesRuleTest {
     @Test
     fun negativeCase() {
         val swagger = getFixture("limitNumberOfSubresourcesInvalid.json")
-        val result = rule.validate(swagger, ignore)!!
-        assertThat(result.paths).hasSameElementsAs(
+        val result = rule.validate(swagger, ignore)
+        assertThat(result?.paths).hasSameElementsAs(
             listOf("/items/{some_id}/item_level_1/{level1_id}/item-level-2/{level2_id}/item-level-3/{level3_id}/item-level-4")
         )
     }

--- a/server/src/test/java/de/zalando/zally/rule/zalando/LimitNumberOfSubresourcesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/LimitNumberOfSubresourcesRuleTest.kt
@@ -1,6 +1,7 @@
 package de.zalando.zally.rule.zalando
 
 import de.zalando.zally.getFixture
+import de.zalando.zally.rule.SwaggerIgnoreExtension
 import de.zalando.zally.testConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -9,31 +10,38 @@ class LimitNumberOfSubresourcesRuleTest {
     val ruleConfig = testConfig
 
     private val rule = LimitNumberOfSubresourcesRule(ruleConfig)
+    private val ignore = SwaggerIgnoreExtension("147")
 
     @Test
     fun positiveCase() {
         val swagger = getFixture("limitNumberOfSubresourcesValid.json")
-        assertThat(rule.validate(swagger)).isNull()
+        assertThat(rule.validate(swagger, ignore)).isNull()
     }
 
     @Test
     fun negativeCase() {
         val swagger = getFixture("limitNumberOfSubresourcesInvalid.json")
-        val result = rule.validate(swagger)!!
+        val result = rule.validate(swagger, ignore)!!
         assertThat(result.paths).hasSameElementsAs(
             listOf("/items/{some_id}/item_level_1/{level1_id}/item-level-2/{level2_id}/item-level-3/{level3_id}/item-level-4")
         )
     }
 
     @Test
+    fun positiveCaseDueToIgnoreExtension() {
+        val swagger = getFixture("limitNumberOfSubresourcesInvalidButIgnored.json")
+        assertThat(rule.validate(swagger, ignore)).isNull()
+    }
+
+    @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(rule.validate(swagger)).isNull()
+        assertThat(rule.validate(swagger, ignore)).isNull()
     }
 
     @Test
     fun positiveCaseSpa() {
         val swagger = getFixture("api_spa.yaml")
-        assertThat(rule.validate(swagger)).isNull()
+        assertThat(rule.validate(swagger, ignore)).isNull()
     }
 }

--- a/server/src/test/resources/fixtures/limitNumberOfSubresourcesInvalidButIgnored.json
+++ b/server/src/test/resources/fixtures/limitNumberOfSubresourcesInvalidButIgnored.json
@@ -1,0 +1,79 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "title" : "Test Service",
+    "description" : "This is a test service.",
+    "version" : "1.0.0",
+    "contact" : {
+      "name" : "John Doe",
+      "email" : "john.doe@example.com"
+    }
+  },
+  "externalDocs" : {
+    "description" : "Some external docs",
+    "url" : "http://some-external-docs.com"
+  },
+  "basePath" : "/api",
+  "schemes" : [ "https" ],
+  "security" : [ {
+    "oauth2" : []
+  } ],
+  "securityDefinitions" : {
+    "oauth2" : {
+      "type" : "oauth2",
+      "flow" : "implicit",
+      "authorizationUrl" : "https://example.com/oauth2/dialog",
+      "scopes" : {
+      }
+    }
+  },
+  "produces" : [ "application/json" ],
+  "paths" : {
+    "/items": {
+      "get" : {
+        "responses": {"200": {"description": ""}}
+      }
+    },
+    "/items/{some_id}": {
+      "get" : {
+        "responses": {"200": {"description": ""}}
+      }
+    },
+    "/items/{some_id}/item_level_1": {
+      "get" : {
+        "responses": {"200": {"description": ""}}
+      }
+    },
+    "/items/{some_id}/item_level_1/{level1_id}": {
+      "get" : {
+        "responses": {"200": {"description": ""}}
+      }
+    },
+    "/items/{some_id}/item-level-1/{level1_id}/item-level-2": {
+      "get" : {
+        "responses": {"200": {"description": ""}}
+      }
+    },
+    "/items/{some_id}/item_level_1/{level1_id}/item-level-2/{level2_id}": {
+      "get" : {
+        "responses": {"200": {"description": ""}}
+      }
+    },
+    "/items/{some_id}/item_level_1/{level1_id}/item-level-2/{level2_id}/item-level-3": {
+      "get" : {
+        "responses": {"200": {"description": ""}}
+      }
+    },
+    "/items/{some_id}/item_level_1/{level1_id}/item-level-2/{level2_id}/item-level-3/{level3_id}": {
+      "get" : {
+        "responses": {"200": {"description": ""}}
+      }
+    },
+    "/items/{some_id}/item_level_1/{level1_id}/item-level-2/{level2_id}/item-level-3/{level3_id}/item-level-4": {
+      "x-zally-ignore": ["147"],
+      "get" : {
+        "responses": {"200": {"description": ""}}
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Check methods now optionally take a SwaggerIgnoreExtension parameter which can be used to process the `x-zally-ignore` anywhere a vendor extension is permitted.
- LimitNumberOfSubresourcesRule modified as it was the example mentioned in #446 

For example the following will only process paths which should not be ignored:
```
@Check(severity = Severity.SHOULD)
fun validate(swagger: Swagger, ignore: SwaggerIgnoreExtension): Violation? {
    val paths = swagger.paths.orEmpty()
        .filterValues { ignore.accepts(it.vendorExtensions) }
```