### PR TITLE
ObjectTreeReader uses swagger-parser utils rather than jackson-dataformat-yaml

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/ObjectTreeReader.kt
+++ b/server/src/main/java/de/zalando/zally/rule/ObjectTreeReader.kt
@@ -1,36 +1,14 @@
 package de.zalando.zally.rule
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import io.swagger.parser.util.DeserializationUtils
 import java.net.URL
 
 class ObjectTreeReader {
 
-    private val jsonRegex = "^\\s*\\{".toRegex()
+    fun read(location: URL): JsonNode =
+            read(location.readText(), location.toString())
 
-    private val jsonMapper = ObjectMapper()
-    private val yamlMapper = ObjectMapper(YAMLFactory())
-
-    fun read(content: String): JsonNode =
-            if (isYaml(content)) {
-                readYaml(content)
-            } else {
-                readJson(content)
-            }
-
-    fun readJson(content: String): JsonNode =
-            jsonMapper.readTree(content)
-
-    fun readYaml(content: String): JsonNode =
-            yamlMapper.readTree(content)
-
-    fun readYaml(yamlUrl: URL): JsonNode =
-            yamlMapper.readTree(yamlUrl)
-
-    fun readJson(jsonUrl: URL): JsonNode =
-            jsonMapper.readTree(jsonUrl)
-
-    private fun isYaml(specContent: String): Boolean =
-            !specContent.matches(jsonRegex)
+    fun read(content: String, location: String = "memory"): JsonNode =
+            DeserializationUtils.deserializeIntoTree(content, location)
 }

--- a/server/src/main/java/de/zalando/zally/rule/ObjectTreeReader.kt
+++ b/server/src/main/java/de/zalando/zally/rule/ObjectTreeReader.kt
@@ -4,11 +4,23 @@ import com.fasterxml.jackson.databind.JsonNode
 import io.swagger.parser.util.DeserializationUtils
 import java.net.URL
 
+/** Utility for reading JSON and YAML into JsonNode trees */
 class ObjectTreeReader {
 
+    /**
+     * Reads the JSON or YAML content of a URL into a JsonNode tree.
+     * @param location the URL to read from
+     * @return a tree of JsonNodes
+     */
     fun read(location: URL): JsonNode =
             read(location.readText(), location.toString())
 
+    /**
+     * Reads JSON or YAML content into a JsonNode tree.
+     * @param content JSON or YAML content
+     * @param location where errors should say the location was, defaults to "memory"
+     * @return a tree of JsonNodes
+     */
     fun read(content: String, location: String = "memory"): JsonNode =
             DeserializationUtils.deserializeIntoTree(content, location)
 }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
@@ -64,7 +64,7 @@ open class UseOpenApiRule(@Autowired rulesConfig: Config) {
         val localResource = Resources.getResource("schemas/json-schema.json").toString()
 
         val schemaUrl = Resources.getResource("schemas/swagger-schema.json")
-        val schema = ObjectTreeReader().readJson(schemaUrl)
+        val schema = ObjectTreeReader().read(schemaUrl)
         return JsonSchemaValidator(schema, schemaRedirects = mapOf(referencedOnlineSchema to localResource))
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/JsonSchemaValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/JsonSchemaValidatorTest.kt
@@ -12,10 +12,10 @@ class JsonSchemaValidatorTest {
         val localResource = Resources.getResource("schemas/simple-referenced-schema.json").toString()
 
         val schemaUrl = Resources.getResource("schemas/simple-schema.json")
-        val json = ObjectTreeReader().readJson(schemaUrl)
+        val json = ObjectTreeReader().read(schemaUrl)
         val jsonSchemaValidator = JsonSchemaValidator(json, mapOf(onlineSchema to localResource))
 
-        val jsonToValidate = ObjectTreeReader().readJson("""
+        val jsonToValidate = ObjectTreeReader().read("""
         {
             "firstName": "MyName",
             "lastName": "MyLastName",
@@ -34,10 +34,10 @@ class JsonSchemaValidatorTest {
         val localResource = Resources.getResource("schemas/json-schema.json").toString()
 
         val schemaUrl = Resources.getResource("schemas/swagger-schema.json")
-        val json = ObjectTreeReader().readJson(schemaUrl)
+        val json = ObjectTreeReader().read(schemaUrl)
         var jsonSchemaValidator = JsonSchemaValidator(json, mapOf(onlineSchema to localResource))
 
-        val specJson = ObjectTreeReader().readYaml(Resources.getResource("fixtures/api_tinbox.yaml"))
+        val specJson = ObjectTreeReader().read(Resources.getResource("fixtures/api_tinbox.yaml"))
 
         val valResult = jsonSchemaValidator.validate(specJson)
         assertThat(valResult.isSuccess).isFalse()

--- a/server/src/test/java/de/zalando/zally/rule/ObjectTreeReaderTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/ObjectTreeReaderTest.kt
@@ -3,10 +3,12 @@ package de.zalando.zally.rule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
+/** Tests for ObjectTreeReader utility */
 class ObjectTreeReaderTest {
 
     private val cut = ObjectTreeReader()
 
+    /** Tests that basic JSON is supported */
     @Test
     fun readSupportsJson() {
         val contents = """
@@ -15,16 +17,17 @@ class ObjectTreeReaderTest {
               "info": {
                 "title": "Things API",
                 "description": "Description of things",
-                "version": "1.0.0"
+                "version": "1.0.1"
               }
             }
             """.trimIndent()
 
         val node = cut.read(contents)
 
-        assertThat(node).hasToString("{\"swagger\":\"2.0\",\"info\":{\"title\":\"Things API\",\"description\":\"Description of things\",\"version\":\"1.0.0\"}}")
+        assertThat(node).hasToString("{\"swagger\":\"2.0\",\"info\":{\"title\":\"Things API\",\"description\":\"Description of things\",\"version\":\"1.0.1\"}}")
     }
 
+    /** Tests that basic YAML is supported */
     @Test
     fun readSupportsYaml() {
         val contents = """
@@ -32,14 +35,15 @@ class ObjectTreeReaderTest {
             info:
               title: Things API
               description: Description of things
-              version: 1.0.0
+              version: 1.0.2
             """.trimIndent()
 
         val node = cut.read(contents)
 
-        assertThat(node).hasToString("{\"swagger\":\"2.0\",\"info\":{\"title\":\"Things API\",\"description\":\"Description of things\",\"version\":\"1.0.0\"}}")
+        assertThat(node).hasToString("{\"swagger\":\"2.0\",\"info\":{\"title\":\"Things API\",\"description\":\"Description of things\",\"version\":\"1.0.2\"}}")
     }
 
+    /** Tests that advanced YAML is supported */
     @Test
     fun readSupportsYamlAnchorsAndReferences() {
 

--- a/server/src/test/java/de/zalando/zally/rule/ObjectTreeReaderTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/ObjectTreeReaderTest.kt
@@ -1,0 +1,71 @@
+package de.zalando.zally.rule
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ObjectTreeReaderTest {
+
+    private val cut = ObjectTreeReader()
+
+    @Test
+    fun readSupportsJson() {
+        val contents = """
+            {
+              "swagger": "2.0",
+              "info": {
+                "title": "Things API",
+                "description": "Description of things",
+                "version": "1.0.0"
+              }
+            }
+            """.trimIndent()
+
+        val node = cut.read(contents)
+
+        assertThat(node).hasToString("{\"swagger\":\"2.0\",\"info\":{\"title\":\"Things API\",\"description\":\"Description of things\",\"version\":\"1.0.0\"}}")
+    }
+
+    @Test
+    fun readSupportsYaml() {
+        val contents = """
+            swagger: '2.0'
+            info:
+              title: Things API
+              description: Description of things
+              version: 1.0.0
+            """.trimIndent()
+
+        val node = cut.read(contents)
+
+        assertThat(node).hasToString("{\"swagger\":\"2.0\",\"info\":{\"title\":\"Things API\",\"description\":\"Description of things\",\"version\":\"1.0.0\"}}")
+    }
+
+    @Test
+    fun readSupportsYamlAnchorsAndReferences() {
+
+        val contents = """
+            Idable:
+              type: object
+              properties:
+                id: &standard-id-property
+                  type: string
+                  format: uuid
+            WriteThing:
+              type: object
+              properties: &thing-editable-properties
+                name:
+                  type: string
+                description:
+                  type: string
+            ReadThing:
+              type: object
+              properties:
+                id: *standard-id-property
+                <<: *thing-editable-properties
+            """.trimIndent()
+
+        val node = cut.read(contents).path("ReadThing").path("properties")
+
+        assertThat(node).hasToString("{\"description\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"id\":{\"type\":\"string\",\"format\":\"uuid\"}}")
+    }
+}


### PR DESCRIPTION
Closes #658