### PR TITLE
Added AvoidXZallyIgnoreRule to explicitly highlight and discourage x-zally-ignore usage

### DIFF
--- a/server/rules.md
+++ b/server/rules.md
@@ -22,6 +22,10 @@ Unused definitions cause confusion and should be avioded.
 
 If all paths start with the same prefix then it would be cleaner to extract that into the basePath rather than repeating for each path.
 
+## H002: Avoid `x-zally-ignore`
+
+The `x-zally-ignore` extension should be used sparingly for temporary exceptional circumstances. Use encourages deviation from agreed standards. For longer term solutions please discuss disabling or adjusting the rule with your team.
+
 ## 131: Use Hyphenated HTTP Headers
 
 Header names should be hyphenated rather than use underscores or other separators

--- a/server/src/main/java/de/zalando/zally/rule/zally/AvoidXZallyIgnoreRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/AvoidXZallyIgnoreRule.kt
@@ -1,0 +1,64 @@
+package de.zalando.zally.rule.zally
+
+import com.fasterxml.jackson.databind.JsonNode
+import de.zalando.zally.rule.api.Check
+import de.zalando.zally.rule.api.Rule
+import de.zalando.zally.rule.api.Severity
+import de.zalando.zally.rule.api.Violation
+
+/**
+ * Rule highlighting that x-zally-ignore should be used sparingly
+ */
+@Rule(
+        ruleSet = ZallyRuleSet::class,
+        id = "H002",
+        severity = Severity.HINT,
+        title = "Avoid using x-zally-ignore extension."
+)
+class AvoidXZallyIgnoreRule {
+
+    private val description = "Ignoring rules should be reserved for exceptional temporary circumstances"
+
+    private val xZallyIgnore = "x-zally-ignore"
+
+    /**
+     * Check the model doesn't use x-zally-ignore
+     * @param root JsonNode root of the spec model
+     * @return Violation iff x-zally-ignore is in use
+     */
+    @Check(severity = Severity.HINT)
+    fun validate(root: JsonNode): Violation? {
+        val paths = validateTree(root)
+        return when {
+            paths.isEmpty() -> null
+            else -> Violation(description, paths)
+        }
+    }
+
+    private fun validateTree(node: JsonNode): List<String> {
+        return when {
+            node.isObject -> validateXZallyIgnore(node) + validateChildren(node)
+            else -> emptyList()
+        }
+    }
+
+    private fun validateXZallyIgnore(node: JsonNode): List<String> {
+        return when {
+            node.has(xZallyIgnore) -> {
+                val ignores = node.get(xZallyIgnore)
+                when {
+                    ignores.isArray -> listOf("ignores rules " + ignores.joinToString(separator = ", ", transform = JsonNode::asText))
+                    ignores.isValueNode -> listOf("invalid ignores, expected list but found single value $ignores")
+                    else -> listOf("invalid ignores, expected list but found $ignores")
+                }
+            }
+            else -> emptyList()
+        }
+    }
+
+    private fun validateChildren(node: JsonNode): List<String> {
+        return node.fields().asSequence().toList().flatMap { (name, child) ->
+            validateTree(child).map { "$name: $it" }
+        }
+    }
+}

--- a/server/src/test/java/de/zalando/zally/rule/zally/AvoidXZallyIgnoreRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/AvoidXZallyIgnoreRuleTest.kt
@@ -1,0 +1,92 @@
+package de.zalando.zally.rule.zally
+
+import de.zalando.zally.rule.ObjectTreeReader
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AvoidXZallyIgnoreRuleTest {
+
+    private val rule = AvoidXZallyIgnoreRule()
+    private val reader = ObjectTreeReader()
+
+    @Test
+    fun validateSpecWithNoIgnores() {
+        val root = reader.read("""
+            swagger: 2.0
+            """.trimIndent())
+
+        val violation = rule.validate(root)
+
+        assertThat(violation).isNull()
+    }
+
+    @Test
+    fun validateSpecWithInlineIgnoresAtRoot() {
+        val root = reader.read("""
+            swagger: 2.0
+            x-zally-ignore: [ ONE, TWO, THREE]
+            """.trimIndent())
+
+        val violation = rule.validate(root)
+
+        assertThat(violation?.paths!!)
+                .hasSameElementsAs(listOf("ignores rules ONE, TWO, THREE"))
+    }
+
+    @Test
+    fun validateSpecWithDashedIgnoresAtRoot() {
+        val root = reader.read("""
+            swagger: 2.0
+            x-zally-ignore:
+              - ONE
+              - TWO
+              - THREE
+            """.trimIndent())
+
+        val violation = rule.validate(root)
+
+        assertThat(violation?.paths!!)
+                .hasSameElementsAs(listOf("ignores rules ONE, TWO, THREE"))
+    }
+
+    @Test
+    fun validateSpecWithInlineIgnoresDeeper() {
+        val root = reader.read("""
+            swagger: 2.0
+            info:
+              x-zally-ignore: [ ONE, TWO, THREE]
+            """.trimIndent())
+
+        val violation = rule.validate(root)
+
+        assertThat(violation?.paths!!)
+                .hasSameElementsAs(listOf("info: ignores rules ONE, TWO, THREE"))
+    }
+
+    @Test
+    fun validateSpecWithInvalidSingleValueIgnores() {
+        val root = reader.read("""
+            swagger: 2.0
+            x-zally-ignore: INVALID
+            """.trimIndent())
+
+        val violation = rule.validate(root)
+
+        assertThat(violation?.paths!!)
+                .hasSameElementsAs(listOf("invalid ignores, expected list but found single value \"INVALID\""))
+    }
+
+    @Test
+    fun validateSpecWithInvalidOtherIgnores() {
+        val root = reader.read("""
+            swagger: 2.0
+            x-zally-ignore:
+              invalid: INVALID
+            """.trimIndent())
+
+        val violation = rule.validate(root)
+
+        assertThat(violation?.paths!!)
+                .hasSameElementsAs(listOf("invalid ignores, expected list but found {\"invalid\":\"INVALID\"}"))
+    }
+}


### PR DESCRIPTION
Figure we might as well get the uncontroversial bit in - and work on the local `x-zally-ignore` support separately.

#446