### PR TITLE
Split SecureAllEndpointsWithScopesRule out from SecureWithOAuth2Rule

### DIFF
--- a/cli/zally/integration_test.go
+++ b/cli/zally/integration_test.go
@@ -65,13 +65,13 @@ func TestIntegrationWithSomeOtherLocalYamlFile(t *testing.T) {
 		out, e := RunAppAndCaptureOutput([]string{"", "lint", "../../server/src/test/resources/fixtures/api_tinbox.yaml"})
 
 		assert.Contains(t, out, "Provide API Specification using OpenAPI")
-		assert.Contains(t, out, "MUST violations: 9")
+		assert.Contains(t, out, "MUST violations: 10")
 		assert.Contains(t, out, "SHOULD violations: 4")
 		assert.Contains(t, out, "MAY violations: 0")
 		assert.Contains(t, out, "HINT violations: 1")
 
 		assert.NotNil(t, e)
-		assert.Equal(t, "Failing because: 9 must violation(s) found", e.Error())
+		assert.Equal(t, "Failing because: 10 must violation(s) found", e.Error())
 	})
 }
 

--- a/server/src/main/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRule.kt
@@ -1,0 +1,96 @@
+package de.zalando.zally.rule.zalando
+
+import com.google.common.collect.Sets
+import com.typesafe.config.Config
+import de.zalando.zally.rule.api.Check
+import de.zalando.zally.rule.api.Rule
+import de.zalando.zally.rule.api.Severity
+import de.zalando.zally.rule.api.Violation
+import io.swagger.models.Operation
+import io.swagger.models.Swagger
+import io.swagger.models.auth.OAuth2Definition
+import org.springframework.beans.factory.annotation.Autowired
+
+@Rule(
+        ruleSet = ZalandoRuleSet::class,
+        id = "105",
+        severity = Severity.MUST,
+        title = "Secure All Endpoints With Scopes"
+)
+class SecureAllEndpointsWithScopesRule(@Autowired rulesConfig: Config) {
+
+    private val pseudoScopes = rulesConfig.getStringList("${SecureAllEndpointsWithScopesRule::class.java.simpleName}.psuedo-scopes")
+
+    private val accessTypes = rulesConfig.getStringList("${SecureAllEndpointsWithScopesRule::class.java.simpleName}.access-types")
+
+    @Check(severity = Severity.MUST)
+    fun checkDefinedScopeFormats(swagger: Swagger): Violation? {
+        return swagger.securityDefinitions.orEmpty().flatMap { (schemeKey, scheme) ->
+            when (scheme) {
+                is OAuth2Definition -> {
+                    scheme.scopes.orEmpty().flatMap { (scope, description) ->
+                        checkDefinedScopeFormat(scope)?.let {
+                            listOf("securityDefinitions $schemeKey $scope: $it")
+                        } ?: emptyList()
+                    }
+                }
+                else -> emptyList()
+            }
+        }.takeIf { it.isNotEmpty() }?.let { Violation("Defined scopes should match an expected format", it) }
+    }
+
+    fun checkDefinedScopeFormat(scope: String): String? {
+        val components = scope.split('.')
+        return when {
+            components.size == 1 ->
+                if (components[0] in pseudoScopes) null
+                else "pseudo-scope '${components[0]}' should be one of $pseudoScopes"
+            components.size > 3 -> "scopes should have no more than 3 dot-separated components"
+            components.last() !in accessTypes -> "access-type '${components.last()}' should be one of $accessTypes"
+            else -> null
+        }
+    }
+
+    @Check(severity = Severity.MUST)
+    fun checkOperationsAreScoped(swagger: Swagger): Violation? {
+        val definedScopes = getDefinedScopes(swagger)
+        val hasTopLevelScope = hasTopLevelScope(swagger, definedScopes)
+        val paths = swagger.paths.orEmpty().entries.flatMap { (pathKey, path) ->
+            path.operationMap.orEmpty().entries.map { (method, operation) ->
+                val actualScopes = extractAppliedScopes(operation)
+                val undefinedScopes = Sets.difference(actualScopes, definedScopes)
+                val unsecured = undefinedScopes.size == actualScopes.size && !hasTopLevelScope
+                val msg = when {
+                    unsecured ->
+                        "no valid OAuth2 scope"
+                    else -> null
+                }
+                if (msg != null) "$pathKey $method has $msg" else null
+            }.filterNotNull()
+        }
+        return if (!paths.isEmpty()) {
+            Violation("Every endpoint must be secured by some scope(s)", paths)
+        } else null
+    }
+
+    // get the scopes from security definition
+    private fun getDefinedScopes(swagger: Swagger): Set<Pair<String, String>> =
+        swagger.securityDefinitions.orEmpty().entries.flatMap { (group, def) ->
+            (def as? OAuth2Definition)?.scopes.orEmpty().keys.map { scope -> group to scope }
+        }.toSet()
+
+    // Extract all oauth2 scopes applied to the given operation into a simple list
+    private fun extractAppliedScopes(operation: Operation): Set<Pair<String, String>> =
+        operation.security?.flatMap { groupDefinition ->
+            groupDefinition.entries.flatMap { (group, scopes) ->
+                scopes.map { group to it }
+            }
+        }.orEmpty().toSet()
+
+    private fun hasTopLevelScope(swagger: Swagger, definedScopes: Set<Pair<String, String>>): Boolean =
+        swagger.security?.any { securityRequirement ->
+            securityRequirement.requirements.entries.any { (group, scopes) ->
+                scopes.any { scope -> (group to scope) in definedScopes }
+            }
+        } ?: false
+}

--- a/server/src/main/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRule.kt
@@ -39,6 +39,11 @@ class SecureAllEndpointsWithScopesRule(@Autowired rulesConfig: Config) {
         }.takeIf { it.isNotEmpty() }?.let { Violation("Defined scopes should match an expected format", it) }
     }
 
+    /**
+     * Check that the supplied scope is acceptable
+     * @param scope the scope to check
+     * @return validation error message or null if the scope is valid
+     */
     fun checkDefinedScopeFormat(scope: String): String? {
         val components = scope.split('.')
         return when {

--- a/server/src/main/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRule.kt
@@ -41,7 +41,7 @@ class SecureAllEndpointsWithScopesRule(@Autowired rulesConfig: Config) {
     private fun checkDefinedScopeFormat(scope: String): String? {
         return when {
             scopeRegex.matches(scope) -> null
-            else -> "scope '$scope' does not match regex '^(uid)|(([a-z-]+\\\\.){1,2}(read|write))\$'"
+            else -> "scope '$scope' does not match regex '$scopeRegex'"
         }
     }
 

--- a/server/src/main/resources/rules-config.conf
+++ b/server/src/main/resources/rules-config.conf
@@ -68,3 +68,9 @@ FormatForNumbersRule {
 ApiAudienceRule {
   audiences: [component-internal, business-unit-internal, company-internal, external-partner, external-public]
 }
+
+SecureAllEndpointsWithScopesRule {
+  psuedo-scopes: [uid]
+  access-types: [read, write]
+}
+

--- a/server/src/main/resources/rules-config.conf
+++ b/server/src/main/resources/rules-config.conf
@@ -70,7 +70,6 @@ ApiAudienceRule {
 }
 
 SecureAllEndpointsWithScopesRule {
-  psuedo-scopes: [uid]
-  access-types: [read, write]
+  scope_regex: "^(uid)|(([a-z-]+\\.){1,2}(read|write))$"
 }
 

--- a/server/src/test/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRuleTest.kt
@@ -7,6 +7,10 @@ import io.swagger.parser.SwaggerParser
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
+/**
+ * Tests for SecureAllEndpointsWithScopesRule
+ */
+@Suppress("StringLiteralDuplication", "UndocumentedPublicFunction", "UnsafeCallOnNullableType", "TooManyFunctions")
 class SecureAllEndpointsWithScopesRuleTest {
 
     private val rule = SecureAllEndpointsWithScopesRule(testConfig)

--- a/server/src/test/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRuleTest.kt
@@ -38,7 +38,7 @@ class SecureAllEndpointsWithScopesRuleTest {
                 scopes:
                   uid: Any logged in user
                   fulfillment-order.read: Can read fulfillment-order app
-                  sales-order.shipment_order.write: Can create shipment_orders in the sales-order app
+                  sales-order.shipment-order.write: Can create shipment-orders in the sales-order app
             """.trimIndent()
         val swagger = SwaggerParser().parse(text)
 
@@ -82,37 +82,7 @@ class SecureAllEndpointsWithScopesRuleTest {
         val violation = rule.checkDefinedScopeFormats(swagger)
 
         assertThat(violation!!.paths)
-                .hasSameElementsAs(listOf("securityDefinitions stups max: pseudo-scope 'max' should be one of [uid]"))
-    }
-
-    @Test
-    fun checkDefinedScopeFormatWithValidPsuedoScopeReturnsNull() {
-        val message = rule.checkDefinedScopeFormat("uid")
-        assertThat(message).isNull()
-    }
-
-    @Test
-    fun checkDefinedScopeFormatWithInvalidPsuedoScopeReturnsMessage() {
-        val message = rule.checkDefinedScopeFormat("full")
-        assertThat(message).isEqualTo("pseudo-scope 'full' should be one of [uid]")
-    }
-
-    @Test
-    fun checkDefinedScopeFormatWithValidAccessTypeReturnsNull() {
-        val message = rule.checkDefinedScopeFormat("stuff.read")
-        assertThat(message).isNull()
-    }
-
-    @Test
-    fun checkDefinedScopeFormatWithValidAccessTypeReturnsMessage() {
-        val message = rule.checkDefinedScopeFormat("stuff.create")
-        assertThat(message).isEqualTo("access-type 'create' should be one of [read, write]")
-    }
-
-    @Test
-    fun checkDefinedScopeFormatWithManyComponentScopeReturnsMessage() {
-        val message = rule.checkDefinedScopeFormat("this.that.the.other")
-        assertThat(message).isEqualTo("scopes should have no more than 3 dot-separated components")
+                .hasSameElementsAs(listOf("securityDefinitions stups max: scope 'max' does not match regex '^(uid)|(([a-z-]+\\\\.){1,2}(read|write))\$'"))
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRuleTest.kt
@@ -1,0 +1,142 @@
+package de.zalando.zally.rule.zalando
+
+import de.zalando.zally.getFixture
+import de.zalando.zally.testConfig
+import io.swagger.models.Swagger
+import io.swagger.parser.SwaggerParser
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SecureAllEndpointsWithScopesRuleTest {
+
+    private val rule = SecureAllEndpointsWithScopesRule(testConfig)
+
+    @Test
+    fun checkDefinedScopesWithNoSecurityReturnsNull() {
+        val text = """
+            swagger: 2.0
+            """.trimIndent()
+        val swagger = SwaggerParser().parse(text)
+
+        val violation = rule.checkDefinedScopeFormats(swagger)
+
+        assertThat(violation)
+                .isNull()
+    }
+
+    @Test
+    fun checkDefinedScopeFormatsWithMatchingScopesReturnsNull() {
+        val text = """
+            swagger: 2.0
+            securityDefinitions:
+              stups:
+                type: oauth2
+                scopes:
+                  uid: Any logged in user
+                  fulfillment-order.read: Can read fulfillment-order app
+                  sales-order.shipment_order.write: Can create shipment_orders in the sales-order app
+            """.trimIndent()
+        val swagger = SwaggerParser().parse(text)
+
+        val violation = rule.checkDefinedScopeFormats(swagger)
+
+        assertThat(violation)
+                .isNull()
+    }
+
+    @Test
+    fun checkDefinedScopeFormatsWithBasicScopesReturnsNull() {
+        val text = """
+            swagger: 2.0
+            securityDefinitions:
+              lazy-in-house-scripts:
+                type: basic
+                scopes:
+                  indexer: Can perform nightly indexing operations
+                  expiry: Can perform automated expiry operations
+            """.trimIndent()
+        val swagger = SwaggerParser().parse(text)
+
+        val violation = rule.checkDefinedScopeFormats(swagger)
+
+        assertThat(violation)
+                .isNull()
+    }
+
+    @Test
+    fun checkDefinedScopeFormatsWithNoMatchingScopesReturnsViolation() {
+        val text = """
+            swagger: 2.0
+            securityDefinitions:
+              stups:
+                type: oauth2
+                scopes:
+                  max: Any user called Max
+            """.trimIndent()
+        val swagger = SwaggerParser().parse(text)
+
+        val violation = rule.checkDefinedScopeFormats(swagger)
+
+        assertThat(violation!!.paths)
+                .hasSameElementsAs(listOf("securityDefinitions stups max: pseudo-scope 'max' should be one of [uid]"))
+    }
+
+    @Test
+    fun checkDefinedScopeFormatWithValidPsuedoScopeReturnsNull() {
+        val message = rule.checkDefinedScopeFormat("uid")
+        assertThat(message).isNull()
+    }
+
+    @Test
+    fun checkDefinedScopeFormatWithInvalidPsuedoScopeReturnsMessage() {
+        val message = rule.checkDefinedScopeFormat("full")
+        assertThat(message).isEqualTo("pseudo-scope 'full' should be one of [uid]")
+    }
+
+    @Test
+    fun checkDefinedScopeFormatWithValidAccessTypeReturnsNull() {
+        val message = rule.checkDefinedScopeFormat("stuff.read")
+        assertThat(message).isNull()
+    }
+
+    @Test
+    fun checkDefinedScopeFormatWithValidAccessTypeReturnsMessage() {
+        val message = rule.checkDefinedScopeFormat("stuff.create")
+        assertThat(message).isEqualTo("access-type 'create' should be one of [read, write]")
+    }
+
+    @Test
+    fun checkDefinedScopeFormatWithManyComponentScopeReturnsMessage() {
+        val message = rule.checkDefinedScopeFormat("this.that.the.other")
+        assertThat(message).isEqualTo("scopes should have no more than 3 dot-separated components")
+    }
+
+    @Test
+    fun checkOperationsAreScopedWithEmpty() {
+        assertThat(rule.checkOperationsAreScoped(Swagger())).isNull()
+    }
+
+    @Test
+    fun checkOperationsAreScopedWithoutScope() {
+        val swagger = getFixture("api_without_scopes_defined.yaml")
+        assertThat(rule.checkOperationsAreScoped(swagger)!!.paths).hasSize(4)
+    }
+
+    @Test
+    fun checkOperationsAreScopedWithDefinedScope() {
+        val swagger = getFixture("api_with_defined_scope.yaml")
+        assertThat(rule.checkOperationsAreScoped(swagger)).isNull()
+    }
+
+    @Test
+    fun checkOperationsAreScopedWithUndefinedScope() {
+        val swagger = getFixture("api_with_undefined_scope.yaml")
+        assertThat(rule.checkOperationsAreScoped(swagger)!!.paths).hasSize(2)
+    }
+
+    @Test
+    fun checkOperationsAreScopedWithDefinedTopLevelScope() {
+        val swagger = getFixture("api_with_toplevel_scope.yaml")
+        assertThat(rule.checkOperationsAreScoped(swagger)).isNull()
+    }
+}

--- a/server/src/test/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/SecureAllEndpointsWithScopesRuleTest.kt
@@ -82,7 +82,7 @@ class SecureAllEndpointsWithScopesRuleTest {
         val violation = rule.checkDefinedScopeFormats(swagger)
 
         assertThat(violation!!.paths)
-                .hasSameElementsAs(listOf("securityDefinitions stups max: scope 'max' does not match regex '^(uid)|(([a-z-]+\\\\.){1,2}(read|write))\$'"))
+                .hasSameElementsAs(listOf("securityDefinitions stups max: scope 'max' does not match regex '^(uid)|(([a-z-]+\\.){1,2}(read|write))\$'"))
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/zalando/SecureWithOAuth2RuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/SecureWithOAuth2RuleTest.kt
@@ -75,37 +75,31 @@ class SecureWithOAuth2RuleTest {
 
     @Test
     fun checkUsedScopesWithEmpty() {
-        assertThat(rule.checkUsedScopes(Swagger())).isNull()
-    }
-
-    @Test
-    fun checkUsedScopesWithoutScope() {
-        val swagger = getFixture("api_without_scopes_defined.yaml")
-        assertThat(rule.checkUsedScopes(swagger)!!.paths).hasSize(4)
+        assertThat(rule.checkUsedScopesAreDefined(Swagger())).isNull()
     }
 
     @Test
     fun checkUsedScopesWithDefinedScope() {
         val swagger = getFixture("api_with_defined_scope.yaml")
-        assertThat(rule.checkUsedScopes(swagger)).isNull()
+        assertThat(rule.checkUsedScopesAreDefined(swagger)).isNull()
     }
 
     @Test
     fun checkUsedScopesWithUndefinedScope() {
         val swagger = getFixture("api_with_undefined_scope.yaml")
-        assertThat(rule.checkUsedScopes(swagger)!!.paths).hasSize(2)
+        assertThat(rule.checkUsedScopesAreDefined(swagger)!!.paths).hasSize(2)
     }
 
     @Test
     fun checkUsedScopesWithDefinedAndUndefinedScope() {
         val swagger = getFixture("api_with_defined_and_undefined_scope.yaml")
-        assertThat(rule.checkUsedScopes(swagger)!!.paths).hasSize(2)
+        assertThat(rule.checkUsedScopesAreDefined(swagger)!!.paths).hasSize(2)
     }
 
     @Test
     fun checkUsedScopesWithDefinedTopLevelScope() {
         val swagger = getFixture("api_with_toplevel_scope.yaml")
-        assertThat(rule.checkUsedScopes(swagger)).isNull()
+        assertThat(rule.checkUsedScopesAreDefined(swagger)).isNull()
     }
 
     @Test

--- a/server/src/test/resources/fixtures/no_must_violations.yaml
+++ b/server/src/test/resources/fixtures/no_must_violations.yaml
@@ -39,10 +39,10 @@ securityDefinitions:
     authorizationUrl: https://example.com/oauth2/dialog
     scopes:
       uid: Unique identifier of the user accessing the service.
-      api-is.api-repository.api-definition.write: Scope allowing the user to write API definitions.
+      api-is.api-repository.write: Scope allowing the user to write API definitions.
 
 security:
-- oauth2: [uid, api-is.api-repository.api-definition.write]
+- oauth2: [uid, api-is.api-repository.write]
 
 parameters:
   ApiId:
@@ -281,7 +281,7 @@ paths:
       security:
       - oauth2:
         - uid
-        - api-is.api-repository.api-definition.write
+        - api-is.api-repository.write
       parameters:
       - $ref: "#/parameters/CrawledAPIDefinition"
       responses:

--- a/server/src/test/resources/fixtures/no_must_violations.yaml
+++ b/server/src/test/resources/fixtures/no_must_violations.yaml
@@ -39,7 +39,7 @@ securityDefinitions:
     authorizationUrl: https://example.com/oauth2/dialog
     scopes:
       uid: Unique identifier of the user accessing the service.
-      api-is.api-repository.write: Scope allowing the user to write API definitions.
+      api-is.api-definition.write: Scope allowing the user to write API definitions.
 
 security:
 - oauth2: [uid, api-is.api-repository.write]
@@ -281,7 +281,6 @@ paths:
       security:
       - oauth2:
         - uid
-        - api-is.api-repository.write
       parameters:
       - $ref: "#/parameters/CrawledAPIDefinition"
       responses:


### PR DESCRIPTION
- Stopped `SecureWithOAuth2Rule` from checking that all end points are secured since that's defined as guideline 105 not 104
- Added `SecureAllEndpointsWithScopesRule` to represent guideline 104 and house the code removed above
- Added `SecureAllEndpointsWithScopesRule.checkDefinedScopeFormats(..)` to verify that scopes match expected formats to complete the implementation of guideline 104.

Discussed in #656 
