### PR TITLE
Proxy for Swagger object

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/model/SwaggerProxy.java
+++ b/server/src/main/java/de/zalando/zally/rule/model/SwaggerProxy.java
@@ -1,0 +1,137 @@
+package de.zalando.zally.rule.model;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.swagger.models.Swagger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cglib.proxy.Enhancer;
+import org.springframework.cglib.proxy.MethodInterceptor;
+import org.springframework.cglib.proxy.MethodProxy;
+
+/**
+ * CGLib proxy for filtering objects using <code>getVendorExtensions</code> method and provided predicate.
+ */
+public class SwaggerProxy {
+
+
+    private static final Logger LOG = LoggerFactory.getLogger(SwaggerProxy.class);
+
+    private static final String EXTENSIONS_METHOD_NAME = "getVendorExtensions";
+
+    private final Function<Map<String, Object>, Boolean> predicate;
+
+
+    public SwaggerProxy(Function<Map<String, Object>, Boolean> predicate) {
+        this.predicate = predicate;
+    }
+
+    public Swagger build(Swagger original) {
+        return (Swagger) buildProxy(original);
+    }
+
+    private Object buildProxy(Object original) {
+        if (original == null) {
+            return null;
+        }
+        if (Enhancer.isEnhanced(original.getClass())) {
+            return original;
+        }
+        LOG.debug("Proxying {} instance", original.getClass().getName());
+        Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(original.getClass());
+        enhancer.setCallback(new Interceptor(original));
+        return enhancer.create();
+    }
+
+    @SuppressWarnings("unchecked")
+    private class Interceptor implements MethodInterceptor {
+
+        private final Object original;
+
+        private Interceptor(Object original) {
+            this.original = original;
+        }
+
+        @Override
+        public Object intercept(Object o, Method method, Object[] args, MethodProxy methodProxy) throws Throwable {
+            Object result = method.invoke(original, args);
+            LOG.debug("Checking result of \"{}\" method", method.getName());
+            return filter(result).orElse(null);
+        }
+
+
+        private Optional<Object> filter(final Object obj) {
+            if (obj == null) {
+                return Optional.empty();
+            }
+            if (Map.class.isAssignableFrom(obj.getClass())) {
+                return filterMap((Map<Object, Object>) obj);
+            } else if (List.class.isAssignableFrom(obj.getClass())) {
+                return filterCollection((Collection<Object>) obj, List.class);
+            } else if (Set.class.isAssignableFrom(obj.getClass())) {
+                return filterCollection((Collection<Object>) obj, Set.class);
+            }
+
+            Optional<Method> extensionsMethod = extensionsMethod(obj);
+            if (!extensionsMethod.isPresent()) {
+                return Optional.of(obj);
+            }
+            return extensionsMethod
+                    .flatMap(m -> getExtensions(obj, m))
+                    .flatMap(ext -> predicate.apply(ext) ? Optional.ofNullable(buildProxy(obj)) : Optional.empty());
+        }
+
+
+        private Optional<Object> filterCollection(Collection<Object> source, Class targetCollection) {
+            if (source == null) {
+                return Optional.empty();
+            }
+            return Optional.of(source.stream()
+                    .map(this::filter)
+                    .filter(Optional::isPresent)
+                    .collect(Collectors.toCollection(() -> {
+                        if (Set.class.isAssignableFrom(targetCollection)) {
+                            return new HashSet();
+                        }
+                        return new ArrayList();
+                    })));
+        }
+
+        private Optional<Object> filterMap(Map<Object, Object> object) {
+            Map result = new HashMap();
+            object.forEach((key, value) -> filter(value).ifPresent(v -> result.put(key, v)));
+            return Optional.of(result);
+        }
+
+        private Optional<Map<String, Object>> getExtensions(Object obj, Method method) {
+            try {
+                Map<String, Object> result = (Map<String, Object>) method.invoke(obj);
+                return Optional.ofNullable(result);
+            } catch (Exception e) {
+                LOG.error("Failed to filter value", e);
+                return Optional.empty();
+            }
+        }
+
+        private Optional<Method> extensionsMethod(Object obj) {
+            try {
+                return Optional.of(obj.getClass().getMethod(EXTENSIONS_METHOD_NAME));
+            } catch (Exception e) {
+                return Optional.empty();
+            }
+        }
+
+    }
+
+}

--- a/server/src/test/java/de/zalando/zally/ProxyTest.java
+++ b/server/src/test/java/de/zalando/zally/ProxyTest.java
@@ -1,0 +1,50 @@
+package de.zalando.zally;
+
+import java.util.Map;
+
+import io.swagger.models.Info;
+import io.swagger.models.Path;
+import io.swagger.models.Swagger;
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import de.zalando.zally.rule.model.SwaggerProxy;
+
+public class ProxyTest {
+
+    @Test
+    public void invokeAsUsualWorks() {
+        Swagger swagger = new Swagger();
+        swagger.setInfo(new Info().title("my title"));
+        SwaggerProxy proxy = new SwaggerProxy(stringObjectMap -> true);
+
+        Swagger proxied = proxy.build(swagger);
+        assertThat(proxied.getInfo().getTitle()).isEqualTo("my title");
+    }
+
+    @Test
+    public void filterInfoByVendorExtensions() {
+        Swagger swagger = new Swagger();
+        Info info = new Info().title("my title");
+        info.setVendorExtension("x-zally-ignore", "1");
+        swagger.setInfo(info);
+
+        SwaggerProxy proxy = new SwaggerProxy(map -> !map.containsKey("x-zally-ignore"));
+        Swagger proxied = proxy.build(swagger);
+
+        assertThat(proxied.getInfo()).isNull();
+    }
+
+    @Test
+    public void pathWithExtensionIgnored() {
+        Swagger swagger = TestUtilKt.getFixture("path_with_extension.yaml");
+        SwaggerProxy proxy = new SwaggerProxy(map -> !map.containsKey("x-zally-ignore"));
+        Swagger proxied = proxy.build(swagger);
+
+        Map<String, Path> paths = proxied.getPaths();
+        assertThat(paths.size()).isEqualTo(2);
+        assertThat(paths.keySet().contains("/valid-path")).isTrue();
+        assertThat(paths.keySet().contains("/another-valid-path")).isTrue();
+    }
+}

--- a/server/src/test/resources/fixtures/path_with_extension.yaml
+++ b/server/src/test/resources/fixtures/path_with_extension.yaml
@@ -1,0 +1,36 @@
+swagger: "2.0"
+info:
+  title: Partner Service Adapter
+  description: |
+    Admin APIs for adding, modifying and deleting jobs to retrieve catalog and stock updates from Partners
+  version: "1.0.0"
+  contact:
+    name: Merchant Core - Article (codename ARTMC)
+    email: team-artmc@zalando.de
+host: psa.artmc.zalan.do
+basePath: /
+schemes:
+  - https
+produces:
+  - application/json
+consumes:
+  - application/json
+paths:
+  /:
+    x-zally-ignore: "1"
+    get:
+      description: "Invalid path"
+
+  /ignored-path:
+    x-zally-ignore: "1"
+    get:
+      description: "Another invalid path"
+
+  /valid-path:
+    get:
+      description: "Valid path"
+
+  /another-valid-path:
+    get:
+      description: "Another valid path"
+


### PR DESCRIPTION
`SwaggerProxy` class which allows to filter Swagger model entities using provided predicate.

## How it works

`SwaggerProxy` creates a proxy for `Swagger` model instance using [cglib](https://github.com/cglib/cglib) library. Proxy intercepts all method calls, redirects them to origin and get result. 
Call result is checked whether is had `getVendorExtensions` method or not. If yes then vendorExtensions are extracted and predicate is applied to them. Predicate returns `Boolean` value. 
If predicate returns `true` then result is returned back to the caller. 
If predicate returns `false` then result will be:
* `null` in case of POJO
* filtered `HashMap` in case of `Map`
* filtered `ArrayList` in case of `List`
* filtered `HashSet` in case of `Set`

### Pros
+ `SwaggerProxy` can be easily used with `OpenAPI` object (OpenAPI v3) as well. The only thing that should be changed is vendor extensions method name from `getVendorExtensions` to `getExtensions`.
+ Predicate can be applied to any part of object model regardless where it is located in object graph.
+ Proxies are build on demand only. That means if there are big model but rules uses only part of it then proxies will be built only for used parts of model.

### Cons
- It uses reflection what can slowdown process a bit. It can be easily solved with caching because Swagger model is immutable from rules perspective and rules do not change the model.

