### PR TITLE
BUGFIX: Path with trailing slash respond 403

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ package-lock.json
 scm-source.json
 out/
 **/classes/
+**/.settings/
+**/.classpath
+**/.project
 
 *node_modules
 *.env*

--- a/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.java
+++ b/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.java
@@ -45,11 +45,13 @@ class OAuthConfiguration extends ResourceServerConfigurerAdapter {
             .and()
             .authorizeRequests()
             .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-            .antMatchers("/health").permitAll()
-            .antMatchers("/metrics",
-                "/api-violations",
-                "/supported-rules",
-                "/review-statistics").access("#oauth2.hasScope('uid')")
+            .regexMatchers("/health/?").permitAll()
+            .regexMatchers(
+                "/metrics/?",
+                "/api-violations/?",
+                "/supported-rules/?",
+                "/review-statistics/?")
+            .access("#oauth2.hasScope('uid')")
             .antMatchers("**").denyAll();
 
         http

--- a/server/src/test/java/de/zalando/zally/configuration/PathMatchersTest.kt
+++ b/server/src/test/java/de/zalando/zally/configuration/PathMatchersTest.kt
@@ -1,0 +1,55 @@
+package de.zalando.zally.configuration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
+import org.junit.Test
+import org.mockito.Mockito
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+import org.springframework.security.web.util.matcher.RegexRequestMatcher
+import javax.servlet.http.HttpServletRequest
+
+/**
+ * This serves as a reminder/documentation of how the matchers do work.
+ */
+class PathMatchersTest {
+
+    @Test
+    fun `antMatcher without trailing slash matches just requests without trailing slash`() {
+        val matcher = AntPathRequestMatcher("/metrics")
+        assertThat(matcher.matches(request("/metrics"))).isTrue()
+        assertThat(matcher.matches(request("/metrics/"))).isFalse()
+        assertThat(matcher.matches(request("/metrics/further"))).isFalse()
+    }
+
+    @Test
+    fun `antMatcher with trailing slash matches just requests with trailing slash`() {
+        val matcher = AntPathRequestMatcher("/metrics/")
+        assertThat(matcher.matches(request("/metrics"))).isFalse()
+        assertThat(matcher.matches(request("/metrics/"))).isTrue()
+        assertThat(matcher.matches(request("/metrics/further"))).isFalse()
+    }
+
+    @Test
+    fun `regex matcher matches requests with and without trailing slash`() {
+        val matcher = RegexRequestMatcher("/metrics/?", null)
+        assertThat(matcher.matches(request("/metrics"))).isTrue()
+        assertThat(matcher.matches(request("/metrics/"))).isTrue()
+        assertThat(matcher.matches(request("/metrics/further"))).isFalse()
+    }
+
+    @Test
+    @Ignore("The outcome of this test does not match the behaviour explained in the documentation. Probably cause: unable to correctly mock the `HttpServletRequest`.")
+    fun `mvcMatcher matches requests with and without trailing slash but also unwanted deeper paths`() {
+        val matcher = MvcRequestMatcher(null, "/metrics/")
+        assertThat(matcher.matches(request("/metrics"))).isTrue()
+        assertThat(matcher.matches(request("/metrics/"))).isTrue()
+        assertThat(matcher.matches(request("/metrics/further"))).isTrue()
+    }
+
+    private fun request(path: String) = Mockito.mock(HttpServletRequest::class.java).also {
+        Mockito.`when`(it.servletPath).thenReturn(path)
+        Mockito.`when`(it.contextPath).thenReturn(path)
+        Mockito.`when`(it.requestURI).thenReturn(path)
+    }
+}


### PR DESCRIPTION
closes #770 

Consider that there is no test on the OAUTH configuration at all. Please review carefully, since I am no Spring Security expert.