### PR TITLE
Allow Swagger definitions without OAuth2 scopes

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/DefaultContext.kt
+++ b/server/src/main/java/de/zalando/zally/rule/DefaultContext.kt
@@ -143,36 +143,37 @@ class DefaultContext(override val source: String, openApi: OpenAPI, swagger: Swa
         }
 
         fun createSwaggerContext(content: String, failOnParseErrors: Boolean = false): Context? =
-                SwaggerParser().readWithInfo(content, true)?.let { parseResult ->
+            SwaggerParser().readWithInfo(content, true)?.let { parseResult ->
                 if (failOnParseErrors && parseResult.messages.orEmpty().isNotEmpty()) {
                     val sep = "\n  - "
                     val messageBulletList = parseResult.messages.joinToString(sep)
                     throw RuntimeException("Swagger parsing failed with those errors:$sep$messageBulletList")
                 }
 
-                    val swagger = parseResult.swagger ?: return null
+                val swagger = parseResult.swagger ?: return null
 
-                    // hack to allow OAuth2 definition with no scopes
-                    swagger.securityDefinitions?.values?.filterIsInstance(OAuth2Definition::class.java)?.forEach {
-                        if (it.scopes == null) {
-                            it.scopes = LinkedHashMap()
-                        }
+                // hack to allow OAuth2 definition with no scopes
+                swagger.securityDefinitions?.values?.filterIsInstance(OAuth2Definition::class.java)?.forEach {
+                    if (it.scopes == null) {
+                        it.scopes = LinkedHashMap()
                     }
+                }
 
-                    val convertResult = SwaggerConverter().convert(parseResult)
+                val convertResult = SwaggerConverter().convert(parseResult)
                 if (failOnParseErrors && convertResult.messages.orEmpty().isNotEmpty()) {
                     val sep = "\n  - "
                     val messageBulletList = parseResult.messages.joinToString(sep)
                     throw RuntimeException("Swagger conversion to OpenAPI 3 failed with those errors:$sep$messageBulletList")
-}
-                    convertResult?.openAPI?.let {
-                        try {
-                            ResolverFully(true).resolveFully(it)
-                        } catch (e: NullPointerException) {
-                            log.warn("Failed to fully resolve Swagger schema.", e)
-                        if (failOnParseErrors) throw e }
-                        DefaultContext(content, it, swagger)
-                    }
                 }
+                convertResult?.openAPI?.let {
+                    try {
+                        ResolverFully(true).resolveFully(it)
+                    } catch (e: NullPointerException) {
+                        log.warn("Failed to fully resolve Swagger schema.", e)
+                        if (failOnParseErrors) throw e
+                    }
+                    DefaultContext(content, it, swagger)
+                }
+            }
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/DefaultContextTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/DefaultContextTest.kt
@@ -3,6 +3,7 @@ package de.zalando.zally.rule
 import de.zalando.zally.util.ResourceUtil.resourceToString
 import io.swagger.v3.oas.models.OpenAPI
 import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 class DefaultContextTest {
@@ -55,5 +56,22 @@ class DefaultContextTest {
         """.trimIndent())!!
 
         assertThat(openapi3Context.isOpenAPI3()).isTrue()
+    }
+
+    @Test
+    fun `swagger with OAuth2 but no scopes parses`() {
+        @Language("yaml")
+        val content = """
+                swagger: 2.0
+                info:
+                  title: OAuth2 Definition Without Scopes
+                securityDefinitions:
+                  oauth2:
+                    type: oauth2
+                    flow: implicit
+                paths: {}
+            """.trimIndent()
+
+        assertThat(DefaultContext.createSwaggerContext(content)).isNotNull
     }
 }


### PR DESCRIPTION
Added hack to avoid `NullPointerException` in swagger to openapi conversion code.

Closes #765