### PR TITLE
Fix Use429HeaderForRateLimitRule NullPointerException on paths that have no response

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/DefaultContext.kt
+++ b/server/src/main/java/de/zalando/zally/rule/DefaultContext.kt
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.PathItem.HttpMethod
+import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.parser.OpenAPIV3Parser
 import io.swagger.v3.parser.converter.SwaggerConverter
 import io.swagger.v3.parser.core.models.ParseOptions
@@ -65,6 +66,27 @@ class DefaultContext(
         path.readOperationsMap()
             .orEmpty()
             .filter(operationFilter)
+            .flatMap(action)
+            .filterNotNull()
+    }
+
+    /**
+     * Convenience method for filtering and iterating over the responses in order to create Violations.
+     * @param pathFilter a filter selecting the paths to validate
+     * @param operationFilter a filter selecting the operations to validate
+     * @param responseFilter a filter selecting the responses to validate
+     * @param action the action to perform on filtered items
+     * @return a list of Violations and/or nulls where no violations are necessary
+     */
+    override fun validateResponses(
+        pathFilter: (Map.Entry<String, PathItem>) -> Boolean,
+        operationFilter: (Map.Entry<HttpMethod, Operation>) -> Boolean,
+        responseFilter: (Map.Entry<String, ApiResponse>) -> Boolean,
+        action: (Map.Entry<String, ApiResponse>) -> List<Violation?>
+    ): List<Violation> = validateOperations(pathFilter, operationFilter) { (_, operation) ->
+        operation.responses
+            .orEmpty()
+            .filter(responseFilter)
             .flatMap(action)
             .filterNotNull()
     }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/Use429HeaderForRateLimitRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/Use429HeaderForRateLimitRule.kt
@@ -19,7 +19,7 @@ class Use429HeaderForRateLimitRule {
 
     @Check(severity = Severity.MUST)
     fun checkHeadersForRateLimiting(context: Context): List<Violation> =
-        context.api.paths.values.flatMap { it.readOperations().flatMap { it.responses.entries } }
+        context.api.paths.orEmpty().values.flatMap { it.readOperations().flatMap { it.responses.orEmpty().entries } }
             .filter { (code, _) -> "429" == code }.map { it.value }
             .filterNot { containsRateLimitHeader(it.headers.orEmpty().keys) }
             .map { context.violation(description, it) }

--- a/server/src/test/java/de/zalando/zally/rule/zalando/Use429HeaderForRateLimitRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/Use429HeaderForRateLimitRuleTest.kt
@@ -1,7 +1,9 @@
 package de.zalando.zally.rule.zalando
 
 import de.zalando.zally.getOpenApiContextFromContent
+import de.zalando.zally.getSwaggerContextFromContent
 import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 class Use429HeaderForRateLimitRuleTest {
@@ -10,6 +12,7 @@ class Use429HeaderForRateLimitRuleTest {
 
     @Test
     fun `checkHeadersForRateLimiting should return violation if no rate limit is provided via headers`() {
+        @Language("YAML")
         val content = """
             openapi: 3.0.1
             paths:
@@ -29,6 +32,7 @@ class Use429HeaderForRateLimitRuleTest {
 
     @Test
     fun `checkHeadersForRateLimiting should return no violation if rate limit information is provided via headers`() {
+        @Language("YAML")
         val content = """
             openapi: 3.0.1
             paths:
@@ -40,6 +44,23 @@ class Use429HeaderForRateLimitRuleTest {
                         Retry-After: {}
         """.trimIndent()
         val context = getOpenApiContextFromContent(content)
+
+        val violations = rule.checkHeadersForRateLimiting(context)
+
+        assertThat(violations).isEmpty()
+    }
+
+    @Test
+    fun `checkHeadersForRateLimiting avoid bug 787 NPE on missing response`() {
+        @Language("YAML")
+        val content = """
+            swagger: "2.0"
+            paths:
+              /articles:
+                get:
+                  description: asd
+            """.trimIndent()
+        val context = getSwaggerContextFromContent(content)
 
         val violations = rule.checkHeadersForRateLimiting(context)
 

--- a/server/zally-rule-api/src/main/kotlin/de/zalando/zally/rule/api/Context.kt
+++ b/server/zally-rule-api/src/main/kotlin/de/zalando/zally/rule/api/Context.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonPointer
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.PathItem
+import io.swagger.v3.oas.models.responses.ApiResponse
 
 interface Context {
 
@@ -33,10 +34,32 @@ interface Context {
             action: (Map.Entry<String, PathItem>) -> List<Violation?>
     ): List<Violation>
 
+    /**
+     * Convenience method for filtering and iterating over the operations in order to create Violations.
+     * @param pathFilter a filter selecting the paths to validate
+     * @param operationFilter a filter selecting the operations to validate
+     * @param action the action to perform on filtered items
+     * @return a list of Violations and/or nulls where no violations are necessary
+     */
     fun validateOperations(
-            pathFilter: (Map.Entry<String, PathItem>) -> Boolean = { true },
-            operationFilter: (Map.Entry<PathItem.HttpMethod, Operation>) -> Boolean = { true },
-            action: (Map.Entry<PathItem.HttpMethod, Operation>) -> List<Violation?>
+        pathFilter: (Map.Entry<String, PathItem>) -> Boolean = { true },
+        operationFilter: (Map.Entry<PathItem.HttpMethod, Operation>) -> Boolean = { true },
+        action: (Map.Entry<PathItem.HttpMethod, Operation>) -> List<Violation?>
+    ): List<Violation>
+
+    /**
+     * Convenience method for filtering and iterating over the responses in order to create Violations.
+     * @param pathFilter a filter selecting the paths to validate
+     * @param operationFilter a filter selecting the operations to validate
+     * @param responseFilter a filter selecting the responses to validate
+     * @param action the action to perform on filtered items
+     * @return a list of Violations and/or nulls where no violations are necessary
+     */
+    fun validateResponses(
+        pathFilter: (Map.Entry<String, PathItem>) -> Boolean = { true },
+        operationFilter: (Map.Entry<PathItem.HttpMethod, Operation>) -> Boolean = { true },
+        responseFilter: (Map.Entry<String, ApiResponse>) -> Boolean = { true },
+        action: (Map.Entry<String, ApiResponse>) -> List<Violation?>
     ): List<Violation>
 
     /**


### PR DESCRIPTION
- Added test demonstrating problem to prevent recurrence.
- Simple fix with `.orEmpty()` calls.
- Refactored to use a new `Context.validateResponses()` for future shared safety.

Closes #787 
