### PR TITLE
feat(server): migrate version in info section rule to use context object to support OpenAPI 3

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/zalando/VersionInInfoSectionRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/VersionInInfoSectionRule.kt
@@ -1,30 +1,28 @@
 package de.zalando.zally.rule.zalando
 
 import de.zalando.zally.rule.api.Check
+import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.util.PatternUtil.isVersion
-import io.swagger.models.Swagger
 
 @Rule(
-        ruleSet = ZalandoRuleSet::class,
-        id = "116",
-        severity = Severity.SHOULD,
-        title = "Provide version information"
+    ruleSet = ZalandoRuleSet::class,
+    id = "116",
+    severity = Severity.MUST,
+    title = "Use Semantic Versioning"
 )
 class VersionInInfoSectionRule {
-    private val description = "Only the documentation, not the API itself, needs version information. It should be in the " +
-        "format MAJOR.MINOR.DRAFT."
+    private val description = "Semantic versioning has to be used in format MAJOR.MINOR(.DRAFT)"
+    internal val versionRegex = """^\d+.\d+(.\d+)?$""".toRegex()
 
-    @Check(severity = Severity.SHOULD)
-    fun validate(swagger: Swagger): Violation? {
-        val version = swagger.info?.version
-        val desc = when {
-            version == null -> "Version is missing"
-            !isVersion(version) -> "Specified version has incorrect format: $version"
+    @Check(severity = Severity.MUST)
+    fun checkAPIVersion(context: Context): Violation? {
+        val version = context.api.info?.version?.trim()
+        return when {
+            version == null -> context.violation("$description: version is missing")
+            !version.matches(versionRegex) -> context.violation("$description: incorrect format")
             else -> null
         }
-        return desc?.let { Violation("$description $it", emptyList()) }
     }
 }

--- a/server/src/main/java/de/zalando/zally/util/PatternUtil.kt
+++ b/server/src/main/java/de/zalando/zally/util/PatternUtil.kt
@@ -13,7 +13,6 @@ object PatternUtil {
     private val KEBAB_CASE_PATTERN = "^[a-z]+(?:-[a-z]+)*$".toRegex()
     private val HYPHENATED_PATTERN = "^[A-Za-z0-9.]+(-[A-Za-z0-9.]+)*$".toRegex()
     private val PATH_VARIABLE_PATTERN = "\\{.+}$".toRegex()
-    private val GENERIC_VERSION_PATTERN = "^\\d+\\.\\d+\\.\\d+$".toRegex()
     private val APPLICATION_PROBLEM_JSON_PATTERN = "^application/(problem\\+)?json$".toRegex()
     private val CUSTOM_WITH_VERSIONING_PATTERN = "^\\w+/[-+.\\w]+;v(ersion)?=\\d+$".toRegex()
 
@@ -34,8 +33,6 @@ object PatternUtil {
     fun isKebabCase(input: String): Boolean = input.matches(KEBAB_CASE_PATTERN)
 
     fun isHyphenated(input: String): Boolean = input.matches(HYPHENATED_PATTERN)
-
-    fun isVersion(input: String): Boolean = input.matches(GENERIC_VERSION_PATTERN)
 
     fun isApplicationJsonOrProblemJson(mediaType: String): Boolean =
         mediaType.matches(APPLICATION_PROBLEM_JSON_PATTERN)

--- a/server/src/test/java/de/zalando/zally/util/PatternUtilTest.kt
+++ b/server/src/test/java/de/zalando/zally/util/PatternUtilTest.kt
@@ -9,7 +9,6 @@ import de.zalando.zally.util.PatternUtil.isKebabCase
 import de.zalando.zally.util.PatternUtil.isPascalCase
 import de.zalando.zally.util.PatternUtil.isPathVariable
 import de.zalando.zally.util.PatternUtil.isSnakeCase
-import de.zalando.zally.util.PatternUtil.isVersion
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -109,23 +108,5 @@ class PatternUtilTest {
         assertTrue(isHyphenated("aA"))
         assertTrue(isHyphenated("AA"))
         assertTrue(isHyphenated("CamelCaseIsNotAcceptableAndShouldBeIllegal"))
-    }
-
-    @Test
-    fun checkGenericIsVersion() {
-        assertFalse(isVersion("*"))
-        assertFalse(isVersion("1"))
-        assertFalse(isVersion("1.2"))
-        assertFalse(isVersion("12.3"))
-        assertTrue(isVersion("1.2.3"))
-        assertFalse(isVersion("1.23"))
-        assertTrue(isVersion("1.2.34"))
-        assertTrue(isVersion("123.456.789"))
-        assertFalse(isVersion("1.2.*"))
-        assertFalse(isVersion("1.*"))
-        assertFalse(isVersion("a"))
-        assertFalse(isVersion("1.a"))
-        assertFalse(isVersion("*.1"))
-        assertFalse(isVersion("1.*.2"))
     }
 }


### PR DESCRIPTION
Related to #714