### PR TITLE
feat(server): migrate nested paths may be root paths rule to use context object to support OpenAPI 3

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/zalando/NestedPathsMayBeRootPathsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/NestedPathsMayBeRootPathsRule.kt
@@ -1,28 +1,25 @@
 package de.zalando.zally.rule.zalando
 
 import de.zalando.zally.rule.api.Check
+import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
 import de.zalando.zally.util.PatternUtil.isPathVariable
-import io.swagger.models.Swagger
 
 @Rule(
-        ruleSet = ZalandoRuleSet::class,
-        id = "145",
-        severity = Severity.MAY,
-        title = "Consider Using (Non-) Nested URLs"
+    ruleSet = ZalandoRuleSet::class,
+    id = "145",
+    severity = Severity.MAY,
+    title = "Consider Using (Non-) Nested URLs"
 )
 class NestedPathsMayBeRootPathsRule {
-    private val description = "Nested paths / URLs may be top-level resource"
+    private val description = "Nested paths may be top-level resource"
 
     @Check(severity = Severity.MAY)
-    fun validate(swagger: Swagger): Violation? {
-        val paths = swagger.paths.orEmpty().keys.filter {
-            val pathSegments = it.split("/".toRegex())
-            // we are only interested in paths that have sub-resource followed by a param: /path1/{param1}/path2/{param2}
-            pathSegments.size > 4 && isPathVariable(pathSegments.last())
-        }
-        return if (paths.isNotEmpty()) Violation(description, paths) else null
-    }
+    fun checkNestedPaths(context: Context): List<Violation> =
+        context.api.paths.orEmpty().entries
+            .map { (path, pathEntry) -> Pair(pathEntry, path.split("/").filter { isPathVariable(it) }.count()) }
+            .filter { (_, numberOfPathParameters) -> numberOfPathParameters > 1 }
+            .map { (path, _) -> context.violation(description, path) }
 }

--- a/server/src/test/java/de/zalando/zally/rule/zalando/NestedPathsMayBeRootPathsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/NestedPathsMayBeRootPathsRuleTest.kt
@@ -15,7 +15,7 @@ class NestedPathsMayBeRootPathsRuleTest {
         val spec = """
             openapi: 3.0.1
             paths:
-              "/countries/{country-id}/cities/{city-id}": {}
+              "/countries/{country-id}/populated/cities/{city-id}": {}
         """.trimIndent()
         val context = getOpenApiContextFromContent(spec)
 
@@ -24,7 +24,7 @@ class NestedPathsMayBeRootPathsRuleTest {
         assertThat(violations).isNotEmpty
         assertThat(violations[0].description).contains("may be top-level resource")
         assertThat(violations[0].pointer.toString())
-            .isEqualTo("/paths/~1countries~1{country-id}~1cities~1{city-id}")
+            .isEqualTo("/paths/~1countries~1{country-id}~1populated~1cities~1{city-id}")
     }
 
     @Test
@@ -33,7 +33,7 @@ class NestedPathsMayBeRootPathsRuleTest {
         val spec = """
             openapi: 3.0.1
             paths:
-              pets/: {}
+              /pets/dogs: {}
         """.trimIndent()
         val context = getOpenApiContextFromContent(spec)
 

--- a/server/src/test/java/de/zalando/zally/rule/zalando/NestedPathsMayBeRootPathsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/NestedPathsMayBeRootPathsRuleTest.kt
@@ -1,7 +1,8 @@
 package de.zalando.zally.rule.zalando
 
-import de.zalando.zally.getFixture
+import de.zalando.zally.getOpenApiContextFromContent
 import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 class NestedPathsMayBeRootPathsRuleTest {
@@ -9,15 +10,35 @@ class NestedPathsMayBeRootPathsRuleTest {
     private val rule = NestedPathsMayBeRootPathsRule()
 
     @Test
-    fun avoidLinkHeadersValidJson() {
-        val swagger = getFixture("api_spp.json")
-        val result = rule.validate(swagger)!!
-        assertThat(result.paths).hasSameElementsAs(listOf("/products/{product_id}/updates/{update_id}"))
+    fun `checkNestedPaths should return violations for paths containing nested sub resources`() {
+        @Language("YAML")
+        val spec = """
+            openapi: 3.0.1
+            paths:
+              "/countries/{country-id}/cities/{city-id}": {}
+        """.trimIndent()
+        val context = getOpenApiContextFromContent(spec)
+
+        val violations = rule.checkNestedPaths(context)
+
+        assertThat(violations).isNotEmpty
+        assertThat(violations[0].description).contains("may be top-level resource")
+        assertThat(violations[0].pointer.toString())
+            .isEqualTo("/paths/~1countries~1{country-id}~1cities~1{city-id}")
     }
 
     @Test
-    fun avoidLinkHeadersValidYaml() {
-        val swagger = getFixture("api_spa.yaml")
-        assertThat(rule.validate(swagger)).isNull()
+    fun `checkNestedPaths should return no violations if there are no paths containing nested sub resources`() {
+        @Language("YAML")
+        val spec = """
+            openapi: 3.0.1
+            paths:
+              pets/: {}
+        """.trimIndent()
+        val context = getOpenApiContextFromContent(spec)
+
+        val violations = rule.checkNestedPaths(context)
+
+        assertThat(violations).isEmpty()
     }
 }


### PR DESCRIPTION
Related to #714