### PR TITLE
More reliable `x-zally-ignore`

### DIFF
--- a/server/src/main/java/de/zalando/zally/util/ast/ReverseAst.kt
+++ b/server/src/main/java/de/zalando/zally/util/ast/ReverseAst.kt
@@ -10,16 +10,14 @@ class ReverseAst internal constructor(private val objectsToNodes: Map<Any, Node>
     fun getPointer(key: Any): JsonPointer? = objectsToNodes[key]?.pointer
 
     fun isIgnored(pointer: JsonPointer, ignoreValue: String): Boolean =
-        isIgnored(this.pointersToNodes[pointer.toString()], ignoreValue)
-
-    private fun isIgnored(node: Node?, ignoreValue: String): Boolean {
-        return node
+        generateSequence(pointer, JsonPointer::head)
+            .map { pointersToNodes[it.toString()] }
+            .find { it != null }
             ?.let {
-                isIgnored(node.marker, ignoreValue) ||
-                node.hasChildren() && node.children.all { c -> isIgnored(c.marker, ignoreValue) }
+                isIgnored(it.marker, ignoreValue) ||
+                it.hasChildren() && it.children.all { c -> isIgnored(c.marker, ignoreValue) }
             }
             ?: false
-    }
 
     private fun isIgnored(marker: Marker?, ignoreValue: String): Boolean =
         marker != null &&

--- a/server/src/test/java/de/zalando/zally/util/ast/ReverseAstTest.kt
+++ b/server/src/test/java/de/zalando/zally/util/ast/ReverseAstTest.kt
@@ -196,4 +196,28 @@ class ReverseAstTest {
                 .isSameAs(sharedParamPointer)
                 .hasToString("/components/parameters/SharedParam")
     }
+
+    @Test
+    fun `isIgnored even ignores unforeseen descendants of ignored nodes`() {
+        @Language("yaml")
+        val content = """
+            swagger: '2.0'
+            x-zally-ignore: [215, 218, 219]
+            info:
+              title: Some API
+              version: '1.0.0'
+              contact:
+                name: Team X
+                email: team@x.com
+                url: https://team.x.com
+            paths: {}
+            """.trimIndent()
+
+        val swagger = SwaggerParser().parse(content)
+        val ast = ReverseAst.fromObject(swagger).withExtensionMethodNames("getVendorExtensions").build()
+
+        assertThat(ast.isIgnored(JsonPointer.compile(""), "218")).isTrue()
+        assertThat(ast.isIgnored(JsonPointer.compile("/info"), "218")).isTrue()
+        assertThat(ast.isIgnored(JsonPointer.compile("/info/description"), "218")).isTrue()
+    }
 }


### PR DESCRIPTION
Given the following spec:

```
swagger: '2.0'
x-zally-ignore: [215, 218, 219]
info:
  title: Some API
  version: '1.0.0'
  contact:
    name: Team X
    email: team@x.com
    url: https://team.x.com
paths: {}
```

- Rule 218 generated a violation against `/info/description` - a node which doesn't exist in the parsed tree
- Previously this pointer mapped to a null node and therefore no `x-zally-ignore` extensions
- Now, when `/info/description` doesn't resolve to a parsed node, `/info` and if necessary `` are checked for `x-zally-ignore` extensions

Manually tested with @maxim-tschumak's case and rule 183 gets properly ignored.

Closes #799