### PR TITLE
feat(server): NoProtocolInHostRule operates on Context

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/zally/NoProtocolInHostRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/NoProtocolInHostRule.kt
@@ -1,11 +1,22 @@
 package de.zalando.zally.rule.zally
 
+import com.fasterxml.jackson.core.JsonPointer
 import de.zalando.zally.rule.api.Check
+import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
 import io.swagger.models.Swagger
 
+/**
+ * Validates that [Swagger.host] does not contain a url scheme as required by
+ * [OpenAPI 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object).
+ *
+ * > The host (name or ip) serving the API. This MUST be the host only and does not include the scheme nor sub-paths.
+ *
+ * Note that this rule operates on a [Context] but specifically targets [Swagger.host] since the OpenAPI 3.0.0
+ * equivalent [io.swagger.v3.oas.models.servers.Server.url] is a url rather than "host only".
+ */
 @Rule(
         ruleSet = ZallyRuleSet::class,
         id = "M008",
@@ -13,13 +24,15 @@ import io.swagger.models.Swagger
         title = "Host should not contain protocol"
 )
 class NoProtocolInHostRule {
-    private val desc = "Information about protocol should be placed in schema. Current host value '%s' violates this rule"
 
     @Check(severity = Severity.MUST)
-    fun validate(swagger: Swagger): Violation? {
-        val host = swagger.host.orEmpty()
-        return if ("://" in host)
-            Violation(desc.format(host), emptyList())
-        else null
+    fun validate(context: Context): List<Violation> {
+        val host = context.swagger?.host.orEmpty()
+        return when {
+            "://" in host -> listOf(Violation(
+                "'$host' contains protocol information which should be listed separately as schemes",
+                JsonPointer.compile("/host")))
+            else -> emptyList()
+        }
     }
 }

--- a/server/src/main/java/de/zalando/zally/rule/zally/NoProtocolInHostRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/NoProtocolInHostRule.kt
@@ -18,10 +18,10 @@ import io.swagger.models.Swagger
  * equivalent [io.swagger.v3.oas.models.servers.Server.url] is a url rather than "host only".
  */
 @Rule(
-        ruleSet = ZallyRuleSet::class,
-        id = "M008",
-        severity = Severity.MUST,
-        title = "Host should not contain protocol"
+    ruleSet = ZallyRuleSet::class,
+    id = "M008",
+    severity = Severity.MUST,
+    title = "Host should not contain protocol"
 )
 class NoProtocolInHostRule {
 
@@ -29,9 +29,16 @@ class NoProtocolInHostRule {
     fun validate(context: Context): List<Violation> {
         val host = context.swagger?.host.orEmpty()
         return when {
-            "://" in host -> listOf(Violation(
-                "'$host' contains protocol information which should be listed separately as schemes",
-                JsonPointer.compile("/host")))
+
+            context.isOpenAPI3() -> emptyList()
+
+            "://" in host -> listOf(
+                Violation(
+                    "'$host' contains protocol information which should be listed separately as schemes",
+                    JsonPointer.compile("/host")
+                )
+            )
+
             else -> emptyList()
         }
     }

--- a/server/src/test/java/de/zalando/zally/rule/zally/NoProtocolInHostRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/NoProtocolInHostRuleTest.kt
@@ -1,6 +1,5 @@
 package de.zalando.zally.rule.zally
 
-import de.zalando.zally.getContextFromFixture
 import de.zalando.zally.getOpenApiContextFromContent
 import de.zalando.zally.getSwaggerContextFromContent
 import de.zalando.zally.rule.ZallyAssertions
@@ -62,24 +61,6 @@ class NoProtocolInHostRuleTest {
             .assertThat(rule.validate(context))
             .descriptionsEqualTo("'https://google.com' contains protocol information which should be listed separately as schemes")
             .pointersEqualTo("/host")
-    }
-
-    @Test
-    fun `validate swagger with SPP json returns no violations`() {
-        val context = getContextFromFixture("api_spp.json")
-
-        ZallyAssertions
-            .assertThat(rule.validate(context))
-            .isEmpty()
-    }
-
-    @Test
-    fun `validate swagger with SPA yaml returns no violations`() {
-        val context = getContextFromFixture("api_spa.yaml")
-
-        ZallyAssertions
-            .assertThat(rule.validate(context))
-            .isEmpty()
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/zally/NoProtocolInHostRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/NoProtocolInHostRuleTest.kt
@@ -1,54 +1,99 @@
 package de.zalando.zally.rule.zally
 
-import de.zalando.zally.getFixture
-import de.zalando.zally.rule.api.Violation
-import io.swagger.models.Swagger
-import org.assertj.core.api.Assertions.assertThat
+import de.zalando.zally.getContextFromFixture
+import de.zalando.zally.getOpenApiContextFromContent
+import de.zalando.zally.getSwaggerContextFromContent
+import de.zalando.zally.rule.ZallyAssertions
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 class NoProtocolInHostRuleTest {
 
     private val rule = NoProtocolInHostRule()
 
-    val expectedViolation = rule.let {
-        Violation("", emptyList())
+    @Test
+    fun `validate swagger with empty swagger returns no violations`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent("""
+            swagger: 2.0
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .isEmpty()
     }
 
     @Test
-    fun emptySwagger() {
-        val swagger = Swagger()
-        assertThat(rule.validate(swagger)).isNull()
+    fun `validate swagger with simple hostname returns no violations`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent("""
+            swagger: 2.0
+            host: google.com
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .isEmpty()
     }
 
     @Test
-    fun positiveCase() {
-        val swagger = Swagger().apply { host = "google.com" }
-        assertThat(rule.validate(swagger)).isNull()
+    fun `validate swagger with http protocol included returns a violation`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent("""
+            swagger: 2.0
+            host: http://google.com
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .descriptionsEqualTo("'http://google.com' contains protocol information which should be listed separately as schemes")
+            .pointersEqualTo("/host")
     }
 
     @Test
-    fun negativeCaseHttp() {
-        val swagger = Swagger().apply { host = "http://google.com" }
-        val res = rule.validate(swagger)
-        assertThat(res?.copy(description = "")).isEqualTo(expectedViolation)
+    fun `validate swagger with https protocol included returns a violation`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent("""
+            swagger: 2.0
+            host: https://google.com
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .descriptionsEqualTo("'https://google.com' contains protocol information which should be listed separately as schemes")
+            .pointersEqualTo("/host")
     }
 
     @Test
-    fun negativeCaseHttps() {
-        val swagger = Swagger().apply { host = "https://google.com" }
-        val res = rule.validate(swagger)
-        assertThat(res?.copy(description = "")).isEqualTo(expectedViolation)
+    fun `validate swagger with SPP json returns no violations`() {
+        val context = getContextFromFixture("api_spp.json")
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .isEmpty()
     }
 
     @Test
-    fun positiveCaseSpp() {
-        val swagger = getFixture("api_spp.json")
-        assertThat(rule.validate(swagger)).isNull()
+    fun `validate swagger with SPA yaml returns no violations`() {
+        val context = getContextFromFixture("api_spa.yaml")
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .isEmpty()
     }
 
     @Test
-    fun positiveCaseSpa() {
-        val swagger = getFixture("api_spa.yaml")
-        assertThat(rule.validate(swagger)).isNull()
+    fun `validate openapi with url including protocol returns no violations`() {
+        @Language("YAML")
+        val context = getOpenApiContextFromContent("""
+            openapi: 3.0.1
+            servers:
+              - url: https://google.com
+                description: OpenAPI expects a URL, not a hostname, so this is correct!
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .isEmpty()
     }
 }


### PR DESCRIPTION
- Rule updated to operate on `Context` and produce violations with a pointer
- Continues to block `Swagger` hosts with protocols since ["This MUST be the host only and does not include the scheme nor sub-paths"](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object)
- Allows equivalent  `OpenAPI` server urls with protocols since the spec [clearly expects a full URL](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#server-object)

Relates to #834