### PR TITLE
Converted ExtractBasePathRule to use Context

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/zally/ExtractBasePathRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/ExtractBasePathRule.kt
@@ -18,21 +18,23 @@ class ExtractBasePathRule {
     @Check(severity = Severity.HINT)
     fun validate(context: Context): List<Violation> {
         val paths = context.api.paths?.keys.orEmpty()
+        if (paths.size < 2) {
+            return emptyList()
+        }
         val prefix = paths.reduce { s1, s2 -> findCommonPrefix(s1, s2) }
         return when {
-            paths.size < 2 || prefix.isEmpty() -> emptyList()
+            prefix.isEmpty() -> emptyList()
             context.isOpenAPI3() -> violations(prefix, "servers' urls")
             else -> violations(prefix, "basePath")
         }
     }
 
-    fun violations(prefix: String, target: String) =
-        listOf(
-            Violation(
-                "All paths start with prefix '$prefix' which could be part of $target.",
-                JsonPointer.compile("/paths")
-            )
+    private fun violations(prefix: String, target: String) = listOf(
+        Violation(
+            "All paths start with prefix '$prefix' which could be part of $target.",
+            JsonPointer.compile("/paths")
         )
+    )
 
     private fun findCommonPrefix(s1: String, s2: String): String {
         val parts1 = s1.split("/")

--- a/server/src/main/java/de/zalando/zally/rule/zally/ExtractBasePathRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/ExtractBasePathRule.kt
@@ -8,14 +8,12 @@ import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
 
 @Rule(
-        ruleSet = ZallyRuleSet::class,
-        id = "H001",
-        severity = Severity.HINT,
-        title = "Base path can be extracted"
+    ruleSet = ZallyRuleSet::class,
+    id = "H001",
+    severity = Severity.HINT,
+    title = "Base path can be extracted"
 )
 class ExtractBasePathRule {
-
-    private val description = "All paths start with prefix '%s'. This prefix could be part of base path."
 
     @Check(severity = Severity.HINT)
     fun validate(context: Context): List<Violation> {
@@ -23,9 +21,18 @@ class ExtractBasePathRule {
         val prefix = paths.reduce { s1, s2 -> findCommonPrefix(s1, s2) }
         return when {
             paths.size < 2 || prefix.isEmpty() -> emptyList()
-            else -> listOf(Violation(description.format(prefix), emptyList(), JsonPointer.compile("/paths")))
+            context.isOpenAPI3() -> violations(prefix, "servers' urls")
+            else -> violations(prefix, "basePath")
         }
     }
+
+    fun violations(prefix: String, target: String) =
+        listOf(
+            Violation(
+                "All paths start with prefix '$prefix' which could be part of $target.",
+                JsonPointer.compile("/paths")
+            )
+        )
 
     private fun findCommonPrefix(s1: String, s2: String): String {
         val parts1 = s1.split("/")

--- a/server/src/test/java/de/zalando/zally/rule/zally/ExtractBasePathRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/ExtractBasePathRuleTest.kt
@@ -1,9 +1,7 @@
 package de.zalando.zally.rule.zally
 
-import de.zalando.zally.getFixture
 import de.zalando.zally.rule.api.Violation
 import de.zalando.zally.swaggerWithPaths
-import io.swagger.models.Swagger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -11,11 +9,6 @@ class ExtractBasePathRuleTest {
     val DESC_PATTERN = "All paths start with prefix '%s'. This prefix could be part of base path."
 
     private val rule = ExtractBasePathRule()
-
-    @Test
-    fun validateEmptyPath() {
-        assertThat(rule.validate(Swagger())).isNull()
-    }
 
     @Test
     fun simplePositiveCase() {
@@ -64,18 +57,6 @@ class ExtractBasePathRuleTest {
             "/applications/{app_id}",
             "/applications/"
         )
-        assertThat(rule.validate(swagger)).isNull()
-    }
-
-    @Test
-    fun positiveCaseSpp() {
-        val swagger = getFixture("api_spp.json")
-        assertThat(rule.validate(swagger)).isNull()
-    }
-
-    @Test
-    fun positiveCaseTinbox() {
-        val swagger = getFixture("api_tinbox.yaml")
         assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/zally/ExtractBasePathRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/ExtractBasePathRuleTest.kt
@@ -11,6 +11,18 @@ class ExtractBasePathRuleTest {
     private val rule = ExtractBasePathRule()
 
     @Test
+    fun `validate swagger with no paths returns no violations`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent("""
+            swagger: 2.0
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .isEmpty()
+    }
+
+    @Test
     fun `validate swagger with no common first segments returns no violations`() {
         @Language("YAML")
         val context = getSwaggerContextFromContent("""

--- a/server/src/test/java/de/zalando/zally/rule/zally/ExtractBasePathRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/ExtractBasePathRuleTest.kt
@@ -1,5 +1,6 @@
 package de.zalando.zally.rule.zally
 
+import de.zalando.zally.getOpenApiContextFromContent
 import de.zalando.zally.getSwaggerContextFromContent
 import de.zalando.zally.rule.ZallyAssertions
 import org.intellij.lang.annotations.Language
@@ -52,7 +53,7 @@ class ExtractBasePathRuleTest {
 
         ZallyAssertions
             .assertThat(rule.validate(context))
-            .descriptionsEqualTo("All paths start with prefix '/shipment'. This prefix could be part of base path.")
+            .descriptionsEqualTo("All paths start with prefix '/shipment' which could be part of basePath.")
             .pointersEqualTo("/paths")
     }
 
@@ -70,7 +71,7 @@ class ExtractBasePathRuleTest {
 
         ZallyAssertions
             .assertThat(rule.validate(context))
-            .descriptionsEqualTo("All paths start with prefix '/queue/models'. This prefix could be part of base path.")
+            .descriptionsEqualTo("All paths start with prefix '/queue/models' which could be part of basePath.")
             .pointersEqualTo("/paths")
     }
 
@@ -89,5 +90,22 @@ class ExtractBasePathRuleTest {
         ZallyAssertions
             .assertThat(rule.validate(context))
             .isEmpty()
+    }
+
+    @Test
+    fun `validate openapi with common first segment returns violation`() {
+        @Language("YAML")
+        val context = getOpenApiContextFromContent("""
+            openapi: 3.0.1
+            paths:
+              /shipment/{shipment_id}: {}
+              /shipment/{shipment_id}/status: {}
+              /shipment/{shipment_id}/details: {}
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .descriptionsEqualTo("All paths start with prefix '/shipment' which could be part of servers' urls.")
+            .pointersEqualTo("/paths")
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/zally/ExtractBasePathRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/ExtractBasePathRuleTest.kt
@@ -1,62 +1,93 @@
 package de.zalando.zally.rule.zally
 
-import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.swaggerWithPaths
-import org.assertj.core.api.Assertions.assertThat
+import de.zalando.zally.getSwaggerContextFromContent
+import de.zalando.zally.rule.ZallyAssertions
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 class ExtractBasePathRuleTest {
-    val DESC_PATTERN = "All paths start with prefix '%s'. This prefix could be part of base path."
 
     private val rule = ExtractBasePathRule()
 
     @Test
-    fun simplePositiveCase() {
-        val swagger = swaggerWithPaths("/orders/{order_id}", "/orders/{updates}", "/merchants")
-        assertThat(rule.validate(swagger)).isNull()
+    fun `validate swagger with no common first segments returns no violations`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent("""
+            swagger: 2.0
+            paths:
+              /orders/{order_id}: {}
+              /orders/{updates}: {}
+              /merchants: {}
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .isEmpty()
     }
 
     @Test
-    fun singlePathShouldPass() {
-        val swagger = swaggerWithPaths("/orders/{order_id}")
-        assertThat(rule.validate(swagger)).isNull()
+    fun `validate swagger with single path returns no violations`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent("""
+            swagger: 2.0
+            paths:
+              /orders/{order_id}: {}
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .isEmpty()
     }
 
     @Test
-    fun simpleNegativeCase() {
-        val swagger = swaggerWithPaths(
-            "/shipment/{shipment_id}",
-            "/shipment/{shipment_id}/status",
-            "/shipment/{shipment_id}/details"
-        )
-        val rule = rule
-        val expected = Violation(DESC_PATTERN.format("/shipment"),
-                emptyList())
-        assertThat(rule.validate(swagger)).isEqualTo(expected)
+    fun `validate swagger with common first segment returns violation`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent("""
+            swagger: 2.0
+            paths:
+              /shipment/{shipment_id}: {}
+              /shipment/{shipment_id}/status: {}
+              /shipment/{shipment_id}/details: {}
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .descriptionsEqualTo("All paths start with prefix '/shipment'. This prefix could be part of base path.")
+            .pointersEqualTo("/paths")
     }
 
     @Test
-    fun multipleResourceNegativeCase() {
-        val swagger = swaggerWithPaths(
-            "/queue/models/configs/{config-id}",
-            "/queue/models/",
-            "/queue/models/{model-id}",
-            "/queue/models/summaries"
-        )
-        val rule = rule
-        val expected = Violation(DESC_PATTERN.format("/queue/models"),
-                emptyList())
-        assertThat(rule.validate(swagger)).isEqualTo(expected)
+    fun `validate swagger with multiple common first segments returns violation`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent("""
+            swagger: 2.0
+            paths:
+              /queue/models/configs/{config-id}: {}
+              /queue/models/: {}
+              /queue/models/{model-id}: {}
+              /queue/models/summaries: {}
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .descriptionsEqualTo("All paths start with prefix '/queue/models'. This prefix could be part of base path.")
+            .pointersEqualTo("/paths")
     }
 
     @Test
-    fun shouldMatchWholeSubresource() {
-        val swagger = swaggerWithPaths(
-            "/api/{api_id}/deployments",
-            "/api/{api_id}/",
-            "/applications/{app_id}",
-            "/applications/"
-        )
-        assertThat(rule.validate(swagger)).isNull()
+    fun `validate swagger with common prefix but no common first segments returns no violations`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent("""
+            swagger: 2.0
+            paths:
+              /api/{api_id}/deployments: {}
+              /api/{api_id}/: {}
+              /applications/{app_id}: {}
+              /applications/: {}
+            """.trimIndent())
+
+        ZallyAssertions
+            .assertThat(rule.validate(context))
+            .isEmpty()
     }
 }


### PR DESCRIPTION
- test(server): Removed unnecessary tests from ExtractBasePathRuleTest
- refactor(server): Converted ExtractBasePathRule to use Context
- feat(server): ExtractBasePathRule violation messages differ for Swagger vs OpenAPI

Working to #834