### PR TITLE
feat(server): Removed unnecessary Violation.paths property

### DIFF
--- a/server/src/main/java/de/zalando/zally/apireview/ApiReview.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiReview.kt
@@ -82,8 +82,8 @@ class ApiReview : Serializable {
         this.name = OpenApiHelper.extractApiName(apiDefinition)
         this.apiId = OpenApiHelper.extractApiId(apiDefinition)
         this.ruleViolations = violations
-            .map { (_, rule, _, violationType, paths) ->
-                RuleViolation(this, "${rule.title} (${rule.id})", violationType, paths.size)
+            .map { (_, rule, _, violationType, _) ->
+                RuleViolation(this, "${rule.title} (${rule.id})", violationType, 1)
             }
 
         this.numberOfEndpoints = EndpointCounter.count(apiDefinition)

--- a/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
@@ -72,8 +72,8 @@ constructor(
         violation.description,
         violation.violationType,
         violation.ruleSet.url(violation.rule).toString(),
-        violation.paths,
-        if (violation.pointer == null) null else violation.pointer.toString()
+        listOf(violation.pointer.toString()),
+        violation.pointer.toString()
     )
 
     private fun buildViolationsCount(violations: List<Result>): Map<String, Int> {

--- a/server/src/main/java/de/zalando/zally/rule/JsonSchemaValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonSchemaValidator.kt
@@ -46,7 +46,7 @@ class JsonSchemaValidator(val name: String, val schema: JsonNode, schemaRedirect
         return when (keyword) {
             Keywords.oneOf, Keywords.anyOf -> createValidationMessageWithSchemaRefs(node, message, pointer, keyword)
             Keywords.additionalProperties -> createValidationMessageWithSchemaPath(node, message, pointer)
-            else -> Violation(message, emptyList(), pointer)
+            else -> Violation(message, pointer)
         }
     }
 

--- a/server/src/main/java/de/zalando/zally/rule/Result.kt
+++ b/server/src/main/java/de/zalando/zally/rule/Result.kt
@@ -5,32 +5,13 @@ import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.RuleSet
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
-import java.util.Arrays.asList
 
 data class Result(
     val ruleSet: RuleSet,
     val rule: Rule,
     val description: String,
     val violationType: Severity,
-    @Deprecated("Use `pointer` instead.") val paths: List<String>,
-    val pointer: JsonPointer? = null
+    val pointer: JsonPointer
 ) {
-
-    constructor(
-        ruleSet: RuleSet,
-        rule: Rule,
-        description: String,
-        violationType: Severity,
-        pointer: JsonPointer?
-    ) : this(ruleSet, rule, description, violationType, emptyList(), pointer)
-
-    constructor(
-        ruleSet: RuleSet,
-        rule: Rule,
-        description: String,
-        violationType: Severity,
-        vararg paths: String
-    ) : this(ruleSet, rule, description, violationType, asList(*paths))
-
-    fun toViolation(): Violation = Violation(description, paths, pointer)
+    fun toViolation(): Violation = Violation(description, pointer)
 }

--- a/server/src/main/java/de/zalando/zally/rule/Result.kt
+++ b/server/src/main/java/de/zalando/zally/rule/Result.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonPointer
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.RuleSet
 import de.zalando.zally.rule.api.Severity
-import de.zalando.zally.rule.api.Violation
 
 data class Result(
     val ruleSet: RuleSet,
@@ -12,6 +11,4 @@ data class Result(
     val description: String,
     val violationType: Severity,
     val pointer: JsonPointer
-) {
-    fun toViolation(): Violation = Violation(description, pointer)
-}
+)

--- a/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
@@ -6,7 +6,6 @@ import de.zalando.zally.rule.ContentParseResult.ParsedSuccessfully
 import de.zalando.zally.rule.ContentParseResult.ParsedWithErrors
 import de.zalando.zally.rule.api.Violation
 import de.zalando.zally.rule.zalando.UseOpenApiRule
-import de.zalando.zally.util.ast.JsonPointers
 import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationTargetException
 
@@ -76,17 +75,12 @@ abstract class RulesValidator<RootT : Any>(val rules: RulesManager) : ApiValidat
         }
         log.debug("${violations.count()} violations identified")
 
-        // TODO: make pointer not-null and remove usage of `paths`
         return violations
             .filterNot {
-                ignore(root, it.pointer ?: JsonPointers.EMPTY, details.rule.id)
+                ignore(root, it.pointer, details.rule.id)
             }
             .map {
-                if (it.pointer != null) {
-                    Result(details.ruleSet, details.rule, it.description, details.check.severity, it.paths, it.pointer)
-                } else {
-                    Result(details.ruleSet, details.rule, it.description, details.check.severity, it.paths)
-                }
+                Result(details.ruleSet, details.rule, it.description, details.check.severity, it.pointer)
             }
     }
 

--- a/server/src/main/java/de/zalando/zally/rule/zalando/KebabCaseInPathSegmentsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/KebabCaseInPathSegmentsRule.kt
@@ -23,5 +23,5 @@ class KebabCaseInPathSegmentsRule(config: Config) {
 
     @Check(severity = Severity.MUST)
     fun checkKebabCaseInPathSegments(context: Context): List<Violation> =
-        checker.checkPathSegments(context).map { Violation(description, it.pointer!!) }
+        checker.checkPathSegments(context).map { Violation(description, it.pointer) }
 }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/PascalCaseHttpHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/PascalCaseHttpHeadersRule.kt
@@ -23,5 +23,5 @@ class PascalCaseHttpHeadersRule(config: Config) {
     @Check(severity = Severity.SHOULD)
     fun checkHttpHeaders(context: Context): List<Violation> =
         checker.checkHeadersNames(context)
-            .map { Violation("Header has to be Hyphenated-Pascal-Case", it.pointer!!) }
+            .map { Violation("Header has to be Hyphenated-Pascal-Case", it.pointer) }
 }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/SnakeCaseForQueryParamsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/SnakeCaseForQueryParamsRule.kt
@@ -25,5 +25,5 @@ class SnakeCaseForQueryParamsRule(config: Config) {
 
     @Check(severity = Severity.MUST)
     fun checkQueryParameter(context: Context): List<Violation> =
-        checker.checkQueryParameterNames(context).map { Violation(description, it.pointer!!) }
+        checker.checkQueryParameterNames(context).map { Violation(description, it.pointer) }
 }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/SnakeCaseInPropNameRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/SnakeCaseInPropNameRule.kt
@@ -22,5 +22,5 @@ class SnakeCaseInPropNameRule(@Autowired config: Config) {
 
     @Check(severity = Severity.MUST)
     fun checkPropertyNames(context: Context): List<Violation> =
-        checker.checkPropertyNames(context).map { Violation(description, it.pointer!!) }
+        checker.checkPropertyNames(context).map { Violation(description, it.pointer) }
 }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
@@ -13,7 +13,6 @@ import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.util.ast.JsonPointers
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import java.net.URL
@@ -53,7 +52,7 @@ open class UseOpenApiRule(@Autowired rulesConfig: Config) {
             openApi3Spec -> openApi3Validator?.validate(spec).orEmpty()
             else -> swaggerValidator?.validate(spec).orEmpty()
         }.map {
-            Violation("Does not match $currentVersion schema: ${it.description}", it.pointer ?: JsonPointers.EMPTY)
+            Violation("Does not match $currentVersion schema: ${it.description}", it.pointer)
         }
     }
 

--- a/server/src/main/java/de/zalando/zally/rule/zalando/UseProblemJsonRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/UseProblemJsonRule.kt
@@ -49,7 +49,7 @@ class UseProblemJsonRule {
                             .let {
                                 Violation(
                                     "${it.description} ${validation.description}",
-                                    it.pointer?.append(validation.pointer ?: JsonPointers.EMPTY)
+                                    it.pointer.append(validation.pointer)
                                         ?: JsonPointers.EMPTY
                                 )
                             }

--- a/server/src/test/java/de/zalando/zally/apireview/ApiReviewTest.kt
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiReviewTest.kt
@@ -1,5 +1,6 @@
 package de.zalando.zally.apireview
 
+import com.fasterxml.jackson.core.JsonPointer
 import de.zalando.zally.dto.ApiDefinitionRequest
 import de.zalando.zally.rule.Result
 import de.zalando.zally.rule.TestRuleSet
@@ -17,9 +18,9 @@ class ApiReviewTest {
 
     @Test
     fun shouldAggregateRuleTypeCount() {
-        val mustViolation1 = result(Severity.MUST, "/pointer1")
-        val mustViolation2 = result(Severity.MUST, "/pointer2")
-        val shouldViolation = result(Severity.SHOULD, "/pointer3")
+        val mustViolation1 = result(Severity.MUST, JsonPointer.compile("/pointer1"))
+        val mustViolation2 = result(Severity.MUST, JsonPointer.compile("/pointer2"))
+        val shouldViolation = result(Severity.SHOULD, JsonPointer.compile("/pointer3"))
 
         val apiReview =
             ApiReview(ApiDefinitionRequest(), "", "", asList(mustViolation1, mustViolation2, shouldViolation))
@@ -33,8 +34,8 @@ class ApiReviewTest {
     @Test
     @Throws(IOException::class)
     fun shouldCalculateNumberOfEndpoints() {
-        val violation1 = result(Severity.MUST, "/pointer1")
-        val violation2 = result(Severity.MUST, "/pointer2")
+        val violation1 = result(Severity.MUST, JsonPointer.compile("/pointer1"))
+        val violation2 = result(Severity.MUST, JsonPointer.compile("/pointer2"))
 
         val apiDefinition = resourceToString("fixtures/limitNumberOfResourcesValid.json")
 
@@ -51,6 +52,6 @@ class ApiReviewTest {
         assertThat(apiReview.name).isEqualTo("Test Service")
     }
 
-    private fun result(severity: Severity, pointer: String): Result =
+    private fun result(severity: Severity, pointer: JsonPointer): Result =
         Result(TestRuleSet(), UseOpenApiRule::class.java.getAnnotation(Rule::class.java), "", severity, pointer)
 }

--- a/server/src/test/java/de/zalando/zally/dto/ViolationsCounterTest.kt
+++ b/server/src/test/java/de/zalando/zally/dto/ViolationsCounterTest.kt
@@ -1,5 +1,6 @@
 package de.zalando.zally.dto
 
+import com.fasterxml.jackson.core.JsonPointer
 import de.zalando.zally.rule.Result
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
@@ -103,7 +104,7 @@ class ViolationsCounterTest {
                 AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java),
                 "Test Description",
                 severity,
-                "/pointer"
+                JsonPointer.compile("/pointer")
             )
         }
     }

--- a/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
@@ -74,7 +74,7 @@ class RulesValidatorTest {
         val rules = listOf(TestSecondRule())
         val validator = SwaggerRulesValidator(rulesManager(rules))
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
-        assertThat(results.map(Result::toViolation).map(Violation::description))
+        assertThat(results.map(Result::description))
             .containsExactly("dummy3")
     }
 
@@ -83,7 +83,7 @@ class RulesValidatorTest {
         val rules = listOf(TestFirstRule())
         val validator = SwaggerRulesValidator(rulesManager(rules))
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
-        assertThat(results.map(Result::toViolation).map(Violation::description))
+        assertThat(results.map(Result::description))
             .containsExactly("dummy1", "dummy2")
     }
 
@@ -92,7 +92,7 @@ class RulesValidatorTest {
         val rules = listOf(TestFirstRule(), TestSecondRule())
         val validator = SwaggerRulesValidator(rulesManager(rules))
         val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
-        assertThat(results.map(Result::toViolation).map(Violation::description))
+        assertThat(results.map(Result::description))
             .containsExactly("dummy3", "dummy1", "dummy2")
     }
 
@@ -101,7 +101,7 @@ class RulesValidatorTest {
         val rules = listOf(TestFirstRule(), TestSecondRule())
         val validator = SwaggerRulesValidator(rulesManager(rules))
         val results = validator.validate(swaggerContent, RulesPolicy(arrayOf("TestSecondRule")))
-        assertThat(results.map(Result::toViolation).map(Violation::description))
+        assertThat(results.map(Result::description))
             .containsExactly("dummy1", "dummy2")
     }
 

--- a/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
@@ -5,6 +5,7 @@ import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
+import de.zalando.zally.util.ast.JsonPointers
 import io.swagger.models.Swagger
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -25,10 +26,7 @@ class RulesValidatorTest {
 
         @Suppress("UNUSED_PARAMETER")
         @Check(severity = Severity.SHOULD)
-        fun validate(swagger: Swagger): List<Violation> = listOf(
-            Violation("dummy1", listOf("x", "y", "z")),
-            Violation("dummy2", listOf())
-        )
+        fun validate(swagger: Swagger): List<Violation> = listOf("dummy1", "dummy2").map { Violation(it, JsonPointers.EMPTY) }
     }
 
     @Rule(
@@ -41,7 +39,7 @@ class RulesValidatorTest {
 
         @Suppress("UNUSED_PARAMETER")
         @Check(severity = Severity.MUST)
-        fun validate(swagger: Swagger): Violation? = Violation("dummy3", listOf("a"))
+        fun validate(swagger: Swagger): Violation? = Violation("dummy3", JsonPointers.EMPTY)
     }
 
     @Rule(

--- a/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
@@ -12,6 +12,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import kotlin.reflect.full.createInstance
 
+@Suppress("UndocumentedPublicClass", "StringLiteralDuplication")
 class RulesValidatorTest {
 
     private val swaggerContent = javaClass.classLoader.getResource("fixtures/api_spp.json").readText(Charsets.UTF_8)

--- a/server/src/test/java/de/zalando/zally/rule/ViolationsAssert.kt
+++ b/server/src/test/java/de/zalando/zally/rule/ViolationsAssert.kt
@@ -40,7 +40,7 @@ class ViolationsAssert(violations: List<Violation>?) :
 
     fun pointersEqualTo(vararg pointers: String): ViolationsAssert {
         isNotNull
-        ListAssert(actual.map { it.pointer?.toString() }).`as`("pointers").containsExactly(*pointers)
+        ListAssert(actual.map { it.pointer.toString() }).`as`("pointers").containsExactly(*pointers)
         return this
     }
 }

--- a/server/src/test/java/de/zalando/zally/statistic/RestReviewStatisticsTest.kt
+++ b/server/src/test/java/de/zalando/zally/statistic/RestReviewStatisticsTest.kt
@@ -1,5 +1,6 @@
 package de.zalando.zally.statistic
 
+import com.fasterxml.jackson.core.JsonPointer
 import de.zalando.zally.apireview.ApiReview
 import de.zalando.zally.apireview.RestApiBaseTest
 import de.zalando.zally.dto.ApiDefinitionRequest
@@ -138,7 +139,7 @@ class RestReviewStatisticsTest : RestApiBaseTest() {
                 AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java),
                 "",
                 Severity.MUST,
-                "/pointer"
+                JsonPointer.compile("/pointer")
             )
         )
     }

--- a/server/zally-rule-api/src/main/kotlin/de/zalando/zally/rule/api/Violation.kt
+++ b/server/zally-rule-api/src/main/kotlin/de/zalando/zally/rule/api/Violation.kt
@@ -5,12 +5,5 @@ import java.util.Arrays.asList
 
 data class Violation(
     val description: String,
-    @Deprecated("Use `pointer` instead.") val paths: List<String>,
-    val pointer: JsonPointer? = null
-) {
-    @Deprecated("Use JsonPointer constructor instead.")
-    constructor(description: String, paths: List<String>) : this(description, paths, null)
-    @Deprecated("Use JsonPointer constructor instead.")
-    constructor(description: String, vararg paths: String) : this(description, asList(*paths))
-    constructor(description: String, pointer: JsonPointer) : this(description, listOf(pointer.toString()), pointer)
-}
+    val pointer: JsonPointer
+)


### PR DESCRIPTION
* Removed `Violation.paths` since it's no longer being used.
* `Violation.pointer` is no longer optional.

Closes #858