### PR TITLE
feat(server): Add line numbers to Result when source was YAML

### DIFF
--- a/cli/zally/domain/violation.go
+++ b/cli/zally/domain/violation.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -11,15 +12,24 @@ type Violation struct {
 	ViolationType string   `json:"violation_type"`
 	RuleLink      string   `json:"rule_link"`
 	Pointer       string   `json:"pointer"`
+	StartLine     int      `json:"start_line"`
+	EndLine       int      `json:"end_line"`
 	Paths         []string `json:"paths"`
 }
 
-// ToPointerDisplayString returns the violation's Pointer in user friendly display format
+// ToPointerDisplayString returns the pointer of the violation in user friendly display format
 func (v *Violation) ToPointerDisplayString() string {
 	display := v.Pointer
 	display = strings.TrimPrefix(display, "/")
 	display = strings.Replace(display, "/", " > ", -1)
 	display = strings.Replace(display, "~1", "/", -1)
 	display = strings.Replace(display, "~0", "~", -1)
-	return display
+
+	if v.StartLine == 0 || v.EndLine == 0 {
+		return display
+	} else if v.StartLine == v.EndLine {
+		return fmt.Sprintf("%s (line %d)", display, v.StartLine)
+	} else {
+		return fmt.Sprintf("%s (lines %d-%d)", display, v.StartLine, v.EndLine)
+	}
 }

--- a/cli/zally/domain/violation.go
+++ b/cli/zally/domain/violation.go
@@ -8,7 +8,7 @@ import (
 // Violation keeps information about Zally violations
 type Violation struct {
 	Title         string   `json:"title"`
-	Decription    string   `json:"description"`
+	Description   string   `json:"description"`
 	ViolationType string   `json:"violation_type"`
 	RuleLink      string   `json:"rule_link"`
 	Pointer       string   `json:"pointer"`

--- a/cli/zally/domain/violation_test.go
+++ b/cli/zally/domain/violation_test.go
@@ -62,4 +62,28 @@ func TestViolation(t *testing.T) {
 
 		tests.AssertEquals(t, expectedResult, actualResult)
 	})
+
+	t.Run("ToPointerDisplayString returns path with line numbers", func(t *testing.T) {
+		violation.Pointer = "/pointer"
+		violation.StartLine = 5
+		violation.EndLine = 10
+
+		actualResult := violation.ToPointerDisplayString()
+
+		expectedResult := "pointer (lines 5-10)"
+
+		tests.AssertEquals(t, expectedResult, actualResult)
+	})
+
+	t.Run("ToPointerDisplayString returns path with single line number", func(t *testing.T) {
+		violation.Pointer = "/pointer"
+		violation.StartLine = 5
+		violation.EndLine = 5
+
+		actualResult := violation.ToPointerDisplayString()
+
+		expectedResult := "pointer (line 5)"
+
+		tests.AssertEquals(t, expectedResult, actualResult)
+	})
 }

--- a/cli/zally/domain/violation_test.go
+++ b/cli/zally/domain/violation_test.go
@@ -11,7 +11,7 @@ func TestViolation(t *testing.T) {
 	violation.Title = "A Title"
 	violation.RuleLink = "http://example.com/"
 	violation.ViolationType = "MUST"
-	violation.Decription = "Description"
+	violation.Description = "Description"
 
 	t.Run("ToPointerDisplayString returns path without leading slash", func(t *testing.T) {
 		violation.Pointer = "/pointer"

--- a/cli/zally/domain/violations_test.go
+++ b/cli/zally/domain/violations_test.go
@@ -11,7 +11,7 @@ func TestViolations(t *testing.T) {
 	mustViolation.Title = "Must Title"
 	mustViolation.RuleLink = "http://example.com/mustViolation"
 	mustViolation.ViolationType = "MUST"
-	mustViolation.Decription = "Must Description"
+	mustViolation.Description = "Must Description"
 	mustViolation.Pointer = "/pointer/1"
 	mustViolation.Paths = []string{"/path/one", "/path/two"}
 
@@ -19,21 +19,21 @@ func TestViolations(t *testing.T) {
 	shouldViolation.Title = "Should Title"
 	shouldViolation.RuleLink = "http://example.com/shouldViolation"
 	shouldViolation.ViolationType = "SHOULD"
-	shouldViolation.Decription = "Should Description"
+	shouldViolation.Description = "Should Description"
 	shouldViolation.Paths = []string{"/path/three", "/path/four"}
 
 	var mayViolation Violation
 	mayViolation.Title = "May Title"
 	mayViolation.RuleLink = "http://example.com/mayViolation"
 	mayViolation.ViolationType = "MAY"
-	mayViolation.Decription = "May Description"
+	mayViolation.Description = "May Description"
 	mayViolation.Paths = []string{"/path/five", "/path/six"}
 
 	var hintViolation Violation
 	hintViolation.Title = "Hint Title"
 	hintViolation.RuleLink = "http://example.com/hintViolation"
 	hintViolation.ViolationType = "HINT"
-	hintViolation.Decription = "Hint Description"
+	hintViolation.Description = "Hint Description"
 	hintViolation.Pointer = "/pointer/2"
 
 	var violationsCount ViolationsCount

--- a/cli/zally/utils/formatters/markdown_formatter.go
+++ b/cli/zally/utils/formatters/markdown_formatter.go
@@ -67,7 +67,7 @@ func (f *MarkdownFormatter) formatViolation(violation *domain.Violation) string 
 	var buffer bytes.Buffer
 
 	fmt.Fprintf(&buffer, "### `%s` [%s](%s)\n\n", violation.ViolationType, violation.Title, violation.RuleLink)
-	fmt.Fprintf(&buffer, "> %s\n\n", violation.Decription)
+	fmt.Fprintf(&buffer, "> %s\n\n", violation.Description)
 
 	if violation.Pointer != "" {
 		fmt.Fprintf(&buffer, "- %s\n", violation.ToPointerDisplayString())

--- a/cli/zally/utils/formatters/markdown_formatter_test.go
+++ b/cli/zally/utils/formatters/markdown_formatter_test.go
@@ -25,14 +25,14 @@ func TestMarkdownFormatViolations(t *testing.T) {
 		firstViolation.Title = "Test Must"
 		firstViolation.RuleLink = "http://example.com/first-violation"
 		firstViolation.ViolationType = "MUST"
-		firstViolation.Decription = "Test Description"
+		firstViolation.Description = "Test Description"
 		firstViolation.Paths = []string{"/path/one", "/path/two"}
 
 		var secondViolation domain.Violation
 		secondViolation.Title = "Test Should"
 		secondViolation.RuleLink = "http://example.com/second-violation"
 		secondViolation.ViolationType = "SHOULD"
-		secondViolation.Decription = "Test Description"
+		secondViolation.Description = "Test Description"
 		secondViolation.Paths = []string{"/path/one", "/path/two"}
 
 		var violations = []domain.Violation{firstViolation, secondViolation}
@@ -130,7 +130,7 @@ func TestMarkdownFormatViolation(t *testing.T) {
 	violation.Title = "Test Title"
 	violation.RuleLink = "http://example.com/violation"
 	violation.ViolationType = "MUST"
-	violation.Decription = "Test Description"
+	violation.Description = "Test Description"
 
 	t.Run("Converts violation to string in pretty format with just paths", func(t *testing.T) {
 

--- a/cli/zally/utils/formatters/pretty_formatter.go
+++ b/cli/zally/utils/formatters/pretty_formatter.go
@@ -87,7 +87,7 @@ func (f *PrettyFormatter) formatViolation(violation *domain.Violation) string {
 	colorize := f.colorizer.ColorizeByTypeFunc(violation.ViolationType)
 
 	fmt.Fprintf(&buffer, "%s %s\n", colorize(violation.ViolationType), colorize(violation.Title))
-	fmt.Fprintf(&buffer, "\t%s\n", violation.Decription)
+	fmt.Fprintf(&buffer, "\t%s\n", violation.Description)
 	fmt.Fprintf(&buffer, "\t%s\n", violation.RuleLink)
 
 	if violation.Pointer != "" {

--- a/cli/zally/utils/formatters/pretty_formatter_test.go
+++ b/cli/zally/utils/formatters/pretty_formatter_test.go
@@ -16,7 +16,7 @@ func TestPrettyFormatViolations(t *testing.T) {
 		mustViolation.Title = "Must Title"
 		mustViolation.RuleLink = "http://example.com/mustViolation"
 		mustViolation.ViolationType = "MUST"
-		mustViolation.Decription = "Must Description"
+		mustViolation.Description = "Must Description"
 		mustViolation.Paths = []string{"/path/one", "/path/two"}
 		violations := []domain.Violation{mustViolation}
 
@@ -116,7 +116,7 @@ func TestPrettyFormatViolationInPrettyFormat(t *testing.T) {
 	violation.Title = "Test Title"
 	violation.RuleLink = "http://example.com/violation"
 	violation.ViolationType = "MUST"
-	violation.Decription = "Test Description"
+	violation.Description = "Test Description"
 
 	t.Run("Converts violation to string in pretty format with just paths", func(t *testing.T) {
 

--- a/cli/zally/utils/result_printer_test.go
+++ b/cli/zally/utils/result_printer_test.go
@@ -92,7 +92,7 @@ func TestPrintViolations(t *testing.T) {
 	mustViolation.Title = "Must Title"
 	mustViolation.RuleLink = "http://example.com/mustViolation"
 	mustViolation.ViolationType = "MUST"
-	mustViolation.Decription = "Must Description"
+	mustViolation.Description = "Must Description"
 	mustViolation.Paths = []string{"/path/one", "/path/two"}
 	mustViolations := []domain.Violation{mustViolation}
 
@@ -100,7 +100,7 @@ func TestPrintViolations(t *testing.T) {
 	shouldViolation.Title = "Should Title"
 	shouldViolation.RuleLink = "http://example.com/shouldViolation"
 	shouldViolation.ViolationType = "SHOULD"
-	shouldViolation.Decription = "Should Description"
+	shouldViolation.Description = "Should Description"
 	shouldViolation.Paths = []string{"/path/three", "/path/four"}
 	shouldViolations := []domain.Violation{shouldViolation}
 

--- a/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
@@ -73,7 +73,9 @@ constructor(
         violation.violationType,
         violation.ruleSet.url(violation.rule).toString(),
         violation.paths,
-        if (violation.pointer == null) null else violation.pointer.toString()
+        violation.pointer?.toString(),
+        violation.lines?.start,
+        violation.lines?.endInclusive
     )
 
     private fun buildViolationsCount(violations: List<Result>): Map<String, Int> {

--- a/server/src/main/java/de/zalando/zally/dto/ViolationDTO.kt
+++ b/server/src/main/java/de/zalando/zally/dto/ViolationDTO.kt
@@ -10,5 +10,7 @@ data class ViolationDTO(
     var violationType: Severity? = null,
     var ruleLink: String? = null,
     @JsonInclude(Include.NON_NULL) @Deprecated("Use `pointer` instead.") var paths: List<String>? = null,
-    @JsonInclude(Include.NON_NULL) var pointer: String? = null
+    @JsonInclude(Include.NON_NULL) var pointer: String? = null,
+    var startLine: Int? = null,
+    var endLine: Int? = null
 )

--- a/server/src/main/java/de/zalando/zally/rule/JsonPointerLocator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonPointerLocator.kt
@@ -1,0 +1,44 @@
+package de.zalando.zally.rule
+
+import com.fasterxml.jackson.core.JsonPointer
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.nodes.CollectionNode
+import org.yaml.snakeyaml.nodes.MappingNode
+import org.yaml.snakeyaml.nodes.Node
+import org.yaml.snakeyaml.nodes.ScalarNode
+import java.io.StringReader
+
+class JsonPointerLocator(contents: String) {
+
+    private val yaml = when {
+        isJson(contents) -> null
+        else -> Yaml().compose(StringReader(contents))
+    }
+
+    private fun isJson(contents: String): Boolean = contents.trim { it <= ' ' }.startsWith("{")
+
+    fun locate(pointer: JsonPointer): IntRange? = yaml?.let { locate(pointer, yaml) }
+
+    private fun locate(pointer: JsonPointer, node: Node, parent: Node = node): IntRange = when (node) {
+        is MappingNode -> locateMapping(pointer, node)
+        is CollectionNode<*> -> locateCollection(pointer, node)
+        else -> null
+    } ?: parent.startMark.line + 1..node.endMark.line + 1
+
+    private fun locateMapping(pointer: JsonPointer, node: MappingNode): IntRange? = node.value
+        .mapNotNull { tuple ->
+            val keyNode = tuple.keyNode
+            if (keyNode is ScalarNode && pointer.matchesProperty(keyNode.value)) {
+                locate(pointer.tail(), tuple.valueNode, keyNode)
+            } else null
+        }
+        .firstOrNull()
+
+    private fun locateCollection(pointer: JsonPointer, node: CollectionNode<*>): IntRange? = node.value
+        .mapIndexedNotNull { index, any ->
+            if (any is Node && pointer.matchesElement(index)) {
+                locate(pointer.tail(), any)
+            } else null
+        }
+        .firstOrNull()
+}

--- a/server/src/main/java/de/zalando/zally/rule/JsonPointerLocator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonPointerLocator.kt
@@ -8,6 +8,9 @@ import org.yaml.snakeyaml.nodes.Node
 import org.yaml.snakeyaml.nodes.ScalarNode
 import java.io.StringReader
 
+/**
+ * Identifies line locations from JsonPointers.
+ */
 class JsonPointerLocator(contents: String) {
 
     private val yaml = when {
@@ -17,6 +20,9 @@ class JsonPointerLocator(contents: String) {
 
     private fun isJson(contents: String): Boolean = contents.trim { it <= ' ' }.startsWith("{")
 
+    /**
+     * Identify the range of line making up an element indicated by a JsonPointer
+     */
     fun locate(pointer: JsonPointer): IntRange? = yaml?.let { locate(pointer, yaml) }
 
     private fun locate(pointer: JsonPointer, node: Node, parent: Node = node): IntRange = when (node) {

--- a/server/src/main/java/de/zalando/zally/rule/Result.kt
+++ b/server/src/main/java/de/zalando/zally/rule/Result.kt
@@ -13,7 +13,8 @@ data class Result(
     val description: String,
     val violationType: Severity,
     @Deprecated("Use `pointer` instead.") val paths: List<String>,
-    val pointer: JsonPointer? = null
+    val pointer: JsonPointer? = null,
+    val lines: IntRange? = null
 ) {
 
     constructor(
@@ -21,8 +22,9 @@ data class Result(
         rule: Rule,
         description: String,
         violationType: Severity,
-        pointer: JsonPointer?
-    ) : this(ruleSet, rule, description, violationType, emptyList(), pointer)
+        pointer: JsonPointer?,
+        lines: IntRange?
+    ) : this(ruleSet, rule, description, violationType, emptyList(), pointer, lines)
 
     constructor(
         ruleSet: RuleSet,

--- a/server/src/main/resources/api/zally-api.yaml
+++ b/server/src/main/resources/api/zally-api.yaml
@@ -14,7 +14,7 @@ info:
     the number of linting requests and the number of checked endpoints. Additionally, all
     linting results and the linted API specifications can be retrieved.
 
-  version: "2.0.0"
+  version: "2.1.0"
   x-api-id: 48aa0090-25ef-11e8-b467-0ed5f89f718b
   x-audience: company-internal
   contact:
@@ -331,6 +331,16 @@ components:
         pointer:
           type: string
           description: JsonPointer to the violated path in the specification
+        start_line:
+          type: integer
+          format: int32
+          example: 1
+          description: The line starting the violated location, if known
+        end_line:
+          type: integer
+          format: int32
+          example: 5
+          description: The line ending the violated location, if known
 
     ViolationsCount:
       type: object

--- a/server/src/test/java/de/zalando/zally/rule/JsonPointerLocatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/JsonPointerLocatorTest.kt
@@ -1,0 +1,111 @@
+package de.zalando.zally.rule
+
+import com.fasterxml.jackson.core.JsonPointer
+import org.intellij.lang.annotations.Language
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class JsonPointerLocatorTest {
+
+    @Test
+    fun `locate with json and path returns null`() {
+        @Language("JSON")
+        val locator = JsonPointerLocator(
+            """
+            {
+              "a": "value"
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(null, locator.locate(JsonPointer.compile("/a")))
+    }
+
+    @Test
+    fun `locate with yaml and path to key value returns lines`() {
+        @Language("YAML")
+        val locator = JsonPointerLocator(
+            """
+            a: value
+            """.trimIndent()
+        )
+
+        assertEquals(1..1, locator.locate(JsonPointer.compile("/a")))
+    }
+
+    @Test
+    fun `locate with yaml and path to multiline key value returns lines`() {
+        @Language("YAML")
+        val locator = JsonPointerLocator(
+            """
+            a:
+
+              value
+            """.trimIndent()
+        )
+
+        assertEquals(1..3, locator.locate(JsonPointer.compile("/a")))
+    }
+
+    @Test
+    fun `locate with yaml and path to deep key value returns lines`() {
+        @Language("YAML")
+        val locator = JsonPointerLocator(
+            """
+            a:
+              b:
+                c:
+                  d:
+                    value
+            """.trimIndent()
+        )
+
+        assertEquals(4..5, locator.locate(JsonPointer.compile("/a/b/c/d")))
+    }
+
+    @Test
+    fun `locate with yaml and path to indexed value returns lines`() {
+        @Language("YAML")
+        val locator = JsonPointerLocator(
+            """
+            - value
+            """.trimIndent()
+        )
+
+        assertEquals(1..1, locator.locate(JsonPointer.compile("/0")))
+    }
+
+    @Test
+    fun `locate with yaml and path to anchor and reference returns lines`() {
+        @Language("YAML")
+        val locator = JsonPointerLocator(
+            """
+            a: &address
+              b:
+                value
+
+            c:
+              *address
+            """.trimIndent()
+        )
+
+        assertEquals(2..3, locator.locate(JsonPointer.compile("/c/b")))
+    }
+
+    @Test
+    fun `locate with yaml and path to anchor and merge returns lines`() {
+        @Language("YAML")
+        val locator = JsonPointerLocator(
+            """
+            a: &address
+              b:
+                value
+
+            c:
+              <<: *address
+            """.trimIndent()
+        )
+
+        assertEquals(5..6, locator.locate(JsonPointer.compile("/c/b")))
+    }
+}

--- a/server/src/test/java/de/zalando/zally/rule/JsonPointerLocatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/JsonPointerLocatorTest.kt
@@ -5,6 +5,7 @@ import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
 class JsonPointerLocatorTest {
 
     @Test


### PR DESCRIPTION
- Server re-parses YAML files using `SnakeYAML` and looks up line numbers from `Violation.pointer` locations
  - If line numbers for `/path/to/thing` can't be found then line numbers for `/path/to`, `/path` and `​` will be used instead
  - Columns are also available if needed.
- CLI ~~and UI~~ append "(line 4)" or "(lines 4-10)" to pointer display strings
- UI unchanged for now since:
  - I can't get the tests passing locally at the moment (even without changes)
  - Fighting the tests via CI wore me down
  - Appending "(lines 4-10)" was very unimaginative use of the line numbers and we should take time to do much much better.
- No JSON support
  - Would need to find JSON parser that preserves line numbers and navigate via JsonPointer
- Addressed the Codacy commenting complaints in https://github.com/zalando/zally/pull/892/commits/0d2120b6fa14306af22864dd465dacc06b18d151

Partially addresses #78 which is currently closed.