### PR TITLE
API to support permalinks

### DIFF
--- a/server/src/main/java/de/zalando/zally/apireview/ApiReview.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiReview.kt
@@ -29,7 +29,6 @@ class ApiReview : Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
 
-    @Column(nullable = false)
     var externalId: UUID? = null
 
     var name: String? = null

--- a/server/src/main/java/de/zalando/zally/apireview/ApiReview.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiReview.kt
@@ -11,6 +11,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.UUID
 import java.util.Objects
 import javax.persistence.CascadeType
 import javax.persistence.Column
@@ -27,6 +28,9 @@ class ApiReview : Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
+
+    @Column(nullable = false)
+    var externalId: UUID? = null
 
     var name: String? = null
 
@@ -72,6 +76,7 @@ class ApiReview : Serializable {
         apiDefinition: String,
         violations: List<Result> = emptyList()
     ) {
+        this.externalId = UUID.randomUUID()
         this.jsonPayload = request.toString()
         this.apiDefinition = apiDefinition
         this.isSuccessfulProcessed = StringUtils.isNotBlank(apiDefinition)

--- a/server/src/main/java/de/zalando/zally/apireview/ApiReview.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiReview.kt
@@ -82,8 +82,8 @@ class ApiReview : Serializable {
         this.name = OpenApiHelper.extractApiName(apiDefinition)
         this.apiId = OpenApiHelper.extractApiId(apiDefinition)
         this.ruleViolations = violations
-            .map { (_, rule, _, violationType, _) ->
-                RuleViolation(this, "${rule.title} (${rule.id})", violationType, 1)
+            .map { result ->
+                RuleViolation(this, result)
             }
 
         this.numberOfEndpoints = EndpointCounter.count(apiDefinition)

--- a/server/src/main/java/de/zalando/zally/apireview/ApiReviewRepository.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiReviewRepository.kt
@@ -30,5 +30,10 @@ interface ApiReviewRepository : CrudRepository<ApiReview, Long> {
         @Param("userAgent") userAgent: String = "%"
     ): ReviewStatistics
 
+    /**
+     * Find ApiReview instance by it's externalId UUID.
+     *
+     * @return the found ApiReview or null.
+     */
     fun findByExternalId(externalId: UUID): ApiReview?
 }

--- a/server/src/main/java/de/zalando/zally/apireview/ApiReviewRepository.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiReviewRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
+import java.util.UUID
 
 interface ApiReviewRepository : CrudRepository<ApiReview, Long> {
 
@@ -28,4 +29,6 @@ interface ApiReviewRepository : CrudRepository<ApiReview, Long> {
         @Param("to") to: LocalDate,
         @Param("userAgent") userAgent: String = "%"
     ): ReviewStatistics
+
+    fun findByExternalId(externalId: UUID): ApiReview?
 }

--- a/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
@@ -3,11 +3,9 @@ package de.zalando.zally.apireview
 import de.zalando.zally.dto.ApiDefinitionRequest
 import de.zalando.zally.dto.ApiDefinitionResponse
 import de.zalando.zally.dto.ViolationDTO
-import de.zalando.zally.dto.ViolationsCounter
 import de.zalando.zally.exception.InaccessibleResourceUrlException
 import de.zalando.zally.exception.MissingApiDefinitionException
 import de.zalando.zally.rule.ApiValidator
-import de.zalando.zally.rule.Result
 import de.zalando.zally.rule.RulesPolicy
 import de.zalando.zally.rule.api.Severity
 import org.springframework.beans.factory.annotation.Autowired
@@ -40,9 +38,10 @@ constructor(
         val requestPolicy = retrieveRulesPolicy(request)
 
         val violations = rulesValidator.validate(apiDefinition!!, requestPolicy)
-        apiReviewRepository.save(ApiReview(request, userAgent.orEmpty(), apiDefinition, violations))
+        val review = ApiReview(request, userAgent.orEmpty(), apiDefinition, violations)
+        apiReviewRepository.save(review)
 
-        return buildApiDefinitionResponse(violations, userAgent)
+        return buildApiDefinitionResponse(review)
     }
 
     private fun retrieveRulesPolicy(request: ApiDefinitionRequest): RulesPolicy = request.ignoreRules
@@ -59,31 +58,25 @@ constructor(
         throw e
     }
 
-    private fun buildApiDefinitionResponse(violations: List<Result>, userAgent: String?): ApiDefinitionResponse {
-        val response = ApiDefinitionResponse()
-        response.message = serverMessageService.serverMessage(userAgent)
-        response.violations = violations.map { this.toDto(it) }
-        response.violationsCount = buildViolationsCount(violations)
-        return response
-    }
-
-    private fun toDto(violation: Result): ViolationDTO = ViolationDTO(
-        violation.rule.title,
-        violation.description,
-        violation.violationType,
-        violation.ruleSet.url(violation.rule).toString(),
-        listOf(violation.pointer.toString()),
-        violation.pointer.toString(),
-        violation.lines?.start,
-        violation.lines?.endInclusive
+    private fun buildApiDefinitionResponse(review: ApiReview): ApiDefinitionResponse = ApiDefinitionResponse(
+        message = serverMessageService.serverMessage(review.userAgent),
+        violations = review.ruleViolations!!.map {
+            ViolationDTO(
+                it.ruleTitle,
+                it.description,
+                it.type,
+                it.ruleUrl,
+                listOf(it.locationPointer!!),
+                it.locationPointer,
+                it.locationLineStart,
+                it.locationLineEnd
+            )
+        },
+        violationsCount = listOf(
+            Severity.MUST to review.mustViolations,
+            Severity.SHOULD to review.shouldViolations,
+            Severity.MAY to review.mayViolations,
+            Severity.HINT to review.hintViolations
+        ).map { it.first.name.toLowerCase() to it.second }.toMap()
     )
-
-    private fun buildViolationsCount(violations: List<Result>): Map<String, Int> {
-        val counter = ViolationsCounter(violations)
-        return Severity.values()
-            .map { severity ->
-                severity.name.toLowerCase() to counter[severity]
-            }
-            .toMap()
-    }
 }

--- a/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
@@ -59,6 +59,7 @@ constructor(
     }
 
     private fun buildApiDefinitionResponse(review: ApiReview): ApiDefinitionResponse = ApiDefinitionResponse(
+        externalId = review.externalId,
         message = serverMessageService.serverMessage(review.userAgent),
         violations = review.ruleViolations!!.map {
             ViolationDTO(

--- a/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
@@ -50,7 +50,7 @@ constructor(
         apiReviewRepository.save(review)
 
         val location = uriBuilder
-            .path("/api-violations/{id}")
+            .path("/api-violations/{externalId}")
             .buildAndExpand(review.externalId)
             .toUri()
 
@@ -87,13 +87,13 @@ constructor(
     private fun buildApiDefinitionResponse(review: ApiReview): ApiDefinitionResponse = ApiDefinitionResponse(
         externalId = review.externalId,
         message = serverMessageService.serverMessage(review.userAgent),
-        violations = review.ruleViolations!!.map {
+        violations = review.ruleViolations.orEmpty().map {
             ViolationDTO(
                 it.ruleTitle,
                 it.description,
                 it.type,
                 it.ruleUrl,
-                listOf(it.locationPointer!!),
+                listOfNotNull(it.locationPointer),
                 it.locationPointer,
                 it.locationLineStart,
                 it.locationLineEnd

--- a/server/src/main/java/de/zalando/zally/apireview/RuleViolation.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/RuleViolation.kt
@@ -1,6 +1,7 @@
 package de.zalando.zally.apireview
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import de.zalando.zally.rule.Result
 import de.zalando.zally.rule.api.Severity
 import java.io.Serializable
 import javax.persistence.Column
@@ -28,8 +29,26 @@ class RuleViolation : Serializable {
     var name: String? = null
 
     @Column(nullable = false)
+    var ruleTitle: String? = null
+
+    @Column(nullable = false)
+    var ruleUrl: String? = null
+
+    @Column(nullable = false)
+    var description: String? = null
+
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     var type: Severity? = null
+
+    @Column(nullable = false)
+    var locationPointer: String? = null
+
+    @Column(nullable = false)
+    var locationLineStart: Int? = null
+
+    @Column(nullable = false)
+    var locationLineEnd: Int? = null
 
     @Deprecated("")
     @Column(nullable = false)
@@ -42,10 +61,16 @@ class RuleViolation : Serializable {
      */
     protected constructor() : super()
 
-    constructor(apiReview: ApiReview, name: String, type: Severity, occurrence: Int) {
+    constructor(apiReview: ApiReview, result: Result) {
         this.apiReview = apiReview
-        this.name = name
-        this.type = type
-        this.occurrence = occurrence
+        this.name = "${result.rule.title} (${result.rule.id})"
+        this.ruleTitle = result.rule.title
+        this.ruleUrl = result.ruleSet.url(result.rule).toString()
+        this.description = result.description
+        this.type = result.violationType
+        this.locationPointer = result.pointer.toString()
+        this.locationLineStart = result.lines?.start
+        this.locationLineEnd = result.lines?.endInclusive
+        this.occurrence = 1
     }
 }

--- a/server/src/main/java/de/zalando/zally/dto/ApiDefinitionResponse.kt
+++ b/server/src/main/java/de/zalando/zally/dto/ApiDefinitionResponse.kt
@@ -1,6 +1,9 @@
 package de.zalando.zally.dto
 
+import java.util.UUID
+
 data class ApiDefinitionResponse(
+    val externalId: UUID? = null,
     var message: String? = null,
     var violations: List<ViolationDTO>? = null,
     var violationsCount: Map<String, Int>? = null

--- a/server/src/main/java/de/zalando/zally/exception/ApiReviewNotFoundException.kt
+++ b/server/src/main/java/de/zalando/zally/exception/ApiReviewNotFoundException.kt
@@ -3,5 +3,8 @@ package de.zalando.zally.exception
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
+/**
+ * Thrown when the specified ApiReview could not be found.
+ */
 @ResponseStatus(HttpStatus.NOT_FOUND)
 class ApiReviewNotFoundException : RuntimeException()

--- a/server/src/main/java/de/zalando/zally/exception/ApiReviewNotFoundException.kt
+++ b/server/src/main/java/de/zalando/zally/exception/ApiReviewNotFoundException.kt
@@ -1,0 +1,7 @@
+package de.zalando.zally.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+class ApiReviewNotFoundException : RuntimeException()

--- a/server/src/main/resources/api/zally-api.yaml
+++ b/server/src/main/resources/api/zally-api.yaml
@@ -59,8 +59,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LintingResponse'
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: The URI where the validation result can be rerequested.
         400:
           description: Input file not parsable
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'https://opensource.zalando.com/problem/schema.yaml#/Problem'
+        default:
+          description: Error object
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'https://opensource.zalando.com/problem/schema.yaml#/Problem'
+      security:
+      - oauth2:
+        - uid
+
+  '/api-violations/{externalId}':
+    get:
+      summary:
+        Get previous generated validation result
+      description: |
+        Retreive a previous validation result in the same format as when
+        it was originally processed.
+
+        If the idenfied validation result cannot be found then a
+        `404 Not Found` response is returned.
+      parameters:
+      - $ref: '#/components/parameters/ExternalId'
+      responses:
+        200:
+          description: API swagger is OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LintingResponse'
+        404:
+          description: No such API review
           content:
             application/problem+json:
               schema:
@@ -199,6 +240,14 @@ components:
       required: false
       schema:
         type: string
+    ExternalId:
+      name: externalId
+      in: path
+      description: Identifier of a previous validation result
+      required: true
+      schema:
+        type: string
+        format: uuid
 
   schemas:
     LintingRequest:

--- a/server/src/main/resources/api/zally-api.yaml
+++ b/server/src/main/resources/api/zally-api.yaml
@@ -14,7 +14,7 @@ info:
     the number of linting requests and the number of checked endpoints. Additionally, all
     linting results and the linted API specifications can be retrieved.
 
-  version: "2.1.0"
+  version: "2.2.0"
   x-api-id: 48aa0090-25ef-11e8-b467-0ed5f89f718b
   x-audience: company-internal
   contact:

--- a/server/src/main/resources/db/migration/V004__add_rule_violation_details.sql
+++ b/server/src/main/resources/db/migration/V004__add_rule_violation_details.sql
@@ -1,0 +1,6 @@
+ALTER TABLE rule_violation ADD description TEXT;
+ALTER TABLE rule_violation ADD rule_title TEXT;
+ALTER TABLE rule_violation ADD rule_url TEXT;
+ALTER TABLE rule_violation ADD location_pointer TEXT;
+ALTER TABLE rule_violation ADD location_line_start INT;
+ALTER TABLE rule_violation ADD location_line_end INT;

--- a/server/src/main/resources/db/migration/V005__add_api_review_external_id.sql
+++ b/server/src/main/resources/db/migration/V005__add_api_review_external_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE api_review ADD external_id UUID;
+
+CREATE INDEX api_review_external_id_idx ON api_review (external_id)

--- a/server/src/test/java/de/zalando/zally/apireview/ApiViolationsControllerTest.kt
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiViolationsControllerTest.kt
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
+@Suppress("UnsafeCallOnNullableType")
 class ApiViolationsControllerTest {
 
     @Autowired

--- a/server/src/test/java/de/zalando/zally/apireview/ApiViolationsControllerTest.kt
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiViolationsControllerTest.kt
@@ -12,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -32,6 +33,34 @@ class ApiViolationsControllerTest {
             post("/api-violations")
                 .contentType("application/json")
                 .content("{\"api_definition_string\":\"\"}")
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().string(containsString("https://zalando.github.io/restful-api-guidelines")))
+    }
+
+    @Test
+    fun `getExistingViolationResponse with no previous apis responds NotFound`() {
+        mvc!!.perform(
+            get("/api-violations/00000000-0000-0000-0000-000000000000")
+                .accept("application/json")
+        )
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `getExistingViolationResponse with existing responds NotFound`() {
+
+        val location = mvc!!.perform(
+            post("/api-violations")
+                .contentType("application/json")
+                .content("{\"api_definition_string\":\"\"}")
+        )
+            .andExpect(status().isOk)
+            .andReturn().response.getHeaderValue("Location")!!
+
+        mvc.perform(
+            get(location.toString())
+                .accept("application/json")
         )
             .andExpect(status().isOk)
             .andExpect(content().string(containsString("https://zalando.github.io/restful-api-guidelines")))

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.kt
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.kt
@@ -53,6 +53,7 @@ class RestApiViolationsTest : RestApiBaseTest() {
         assertThat(violations!![0].description).isEqualTo("TestCheckAlwaysReport3MustViolations #1")
         assertThat(violations[1].description).isEqualTo("TestCheckAlwaysReport3MustViolations #2")
         assertThat(violations[2].description).isEqualTo("TestCheckAlwaysReport3MustViolations #3")
+        assertThat(response.externalId).isNotNull()
     }
 
     @Test
@@ -65,6 +66,7 @@ class RestApiViolationsTest : RestApiBaseTest() {
         assertThat(count["should"]).isEqualTo(0)
         assertThat(count["may"]).isEqualTo(0)
         assertThat(count["hint"]).isEqualTo(0)
+        assertThat(response.externalId).isNotNull()
     }
 
     @Test
@@ -85,6 +87,7 @@ class RestApiViolationsTest : RestApiBaseTest() {
 
         val violations = response!!.violations
         assertThat(violations).isEmpty()
+        assertThat(response.externalId).isNotNull()
     }
 
     @Test
@@ -126,6 +129,7 @@ class RestApiViolationsTest : RestApiBaseTest() {
         assertThat(response.violations!![0].title).isEqualTo("TestUseOpenApiRule")
         assertThat(response.violations!![0].description).isEqualTo("attribute openapi is not of type `object`")
         assertThat(response.violations!![1].title).isEqualTo("TestCheckIsOpenApi3")
+        assertThat(response.externalId).isNotNull()
     }
 
     @Test


### PR DESCRIPTION
- Modified `POST /api-validations`
  - `api_review` table includes a UUID external identifier.
  - `rule_violation` table include full violation representation.
  - `ApiDefinitionResponse` now built from database content.
  - Response includes a `Location` header like most `201 Created` responses.
  - Response status still `200 OK` since at least the CLI requires that.
- New `GET /api-validations/{uuid}`
  - Responds `200 OK` with the same `ApiDefinitionResponse` built from the database content.
  - Alternatively responds `404 Not Found` when the specified review does not exist.
  - No authorization applied - if you know the UUID you can retrieve API.

Provides API for #593 