### PR TITLE
fix: Correct pluralization/tense of description

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/zalando/PluralizeNamesForArraysRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/PluralizeNamesForArraysRule.kt
@@ -16,7 +16,7 @@ import de.zalando.zally.util.getAllSchemas
 )
 class PluralizeNamesForArraysRule {
 
-    val description = "Array property names has to be pluralized"
+    val description = "Array property name appears to be singular"
 
     @Check(severity = Severity.SHOULD)
     fun checkArrayPropertyNamesArePlural(context: Context): List<Violation> =
@@ -24,5 +24,5 @@ class PluralizeNamesForArraysRule {
             .flatMap { it.properties.orEmpty().entries }
             .filter { "array" == it.value.type }
             .filterNot { isPlural(it.key) }
-            .map { context.violation("$description: ${it.key} ", it.value) }
+            .map { context.violation("$description: ${it.key}", it.value) }
 }

--- a/server/src/test/java/de/zalando/zally/rule/zalando/PluralizeNamesForArraysRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/PluralizeNamesForArraysRuleTest.kt
@@ -1,6 +1,7 @@
 package de.zalando.zally.rule.zalando
 
 import de.zalando.zally.getOpenApiContextFromContent
+import de.zalando.zally.rule.ZallyAssertions
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -27,9 +28,11 @@ class PluralizeNamesForArraysRuleTest {
 
         val violations = rule.checkArrayPropertyNamesArePlural(context)
 
-        assertThat(violations).isNotEmpty
-        assertThat(violations[0].description).containsPattern(".*Array property names has to be pluralized.*")
-        assertThat(violations[0].pointer.toString()).isEqualTo("/components/schemas/car/properties/feature")
+        ZallyAssertions
+            .assertThat(violations)
+            .isNotEmpty
+            .descriptionsAllEqualTo("Array property name appears to be singular: feature")
+            .pointersEqualTo("/components/schemas/car/properties/feature")
     }
 
     @Test


### PR DESCRIPTION
Original wording has bad pluralization and/or tense:

> Array property names has to be pluralized

Replaced with the following:

> Array property name appears to be singular

Adopting less confident phrasing of `PluralizeResourceNamesRule` since programmatic checking of plurals in English is not entirely reliable.

Closes #908 