### PR TITLE
fix(server): run only Zalando checks per default (#957)

### DIFF
--- a/cli/zally/integration_test.go
+++ b/cli/zally/integration_test.go
@@ -82,7 +82,7 @@ func TestIntegrationWithNoMustViolations(t *testing.T) {
 	must, should, may, hint := countViolations(out)
 
 	assert.Zero(t, must)
-	assert.True(t, should > 0)
+	assert.True(t, should == 0)
 	assert.True(t, may > 0)
 	assert.Equal(t, 0, hint)
 	assert.Nil(t, e)

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -29,10 +29,8 @@ twintip:
 rules-config-path: "rules-config.conf"
 
 zally:
-  # Uncomment the `ignoreRules` property below to ignore rules system wide.
-  # Rules are specified using a comma separated list of rule ids.
-  #
-  # ignoreRules: H001, S005
+  # rules to be ignored system wide
+  ignoreRules: M008, M009, M010, H001, H002, S005, S006, S007
   cli:
     releasesPage: https://github.com/zalando/zally/releases
     deprecatedCliAgents: unirest-java/1.3.11,Zally-CLI/1.0


### PR DESCRIPTION
Fixes #957 

@roxspring We always tried to be consistent with the Zalando Guidelines per default. At some point, you commented out the `ignoredRules` and we didn't see that. Now, we want to switch this back. It may impact your setup, so please check that you have your own configuration.