### PR TITLE
Configurable StringPropertyLengthBoundsRule

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/zally/StringPropertyLengthBoundsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/StringPropertyLengthBoundsRule.kt
@@ -21,6 +21,9 @@ class StringPropertyLengthBoundsRule(config: Config) {
         .getStringList("StringPropertyLengthBoundsRule.formatWhitelist")
         .toList()
 
+    internal val patternImpliesLimits = config
+        .getBoolean("StringPropertyLengthBoundsRule.patternImpliesLimits")
+
     @Check(severity = Severity.SHOULD)
     fun checkStringLengthBounds(context: Context): List<Violation> =
         context.api
@@ -29,6 +32,7 @@ class StringPropertyLengthBoundsRule(config: Config) {
                 when {
                     schema.type != "string" -> false
                     schema.format in formatWhitelist -> false
+                    schema.pattern != null && patternImpliesLimits -> false
                     else -> true
                 }
             }

--- a/server/src/main/resources/rules-config.conf
+++ b/server/src/main/resources/rules-config.conf
@@ -245,3 +245,7 @@ ProprietaryHeadersRule {
     "X-RateLimit-Reset"
   ]
 }
+
+StringPropertyLengthBoundsRule {
+  formatWhitelist: [ date, date-time, uuid, ipv4, ipv6 ]
+}

--- a/server/src/main/resources/rules-config.conf
+++ b/server/src/main/resources/rules-config.conf
@@ -248,4 +248,5 @@ ProprietaryHeadersRule {
 
 StringPropertyLengthBoundsRule {
   formatWhitelist: [ date, date-time, uuid, ipv4, ipv6 ]
+  patternImpliesLimits: true
 }

--- a/server/src/test/java/de/zalando/zally/rule/zally/StringPropertyLengthBoundsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/StringPropertyLengthBoundsRuleTest.kt
@@ -248,4 +248,36 @@ class StringPropertyLengthBoundsRuleTest {
             .assertThat(violations)
             .isEmpty()
     }
+
+    @Test
+    fun `checkStringLengthBounds with pattern returns no violations`() {
+        assumeTrue(
+            "Test assumes config StringPropertyLengthBoundsRule.patternImpliesLimits is 'true'",
+            cut.patternImpliesLimits
+        )
+
+        @Language("YAML")
+        val context = getOpenApiContextFromContent(
+            """
+            openapi: 3.0.2
+            info:
+              title: Thing API
+              version: 1.0.0
+            components:
+              schemas:
+                Thing:
+                  type: object
+                  properties:
+                    theString:
+                      type: string
+                      pattern: #([a-f0-9]{6}|[a-f0-9]{3})
+            """.trimIndent()
+        )
+
+        val violations = cut.checkStringLengthBounds(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .isEmpty()
+    }
 }

--- a/server/src/test/java/de/zalando/zally/rule/zally/StringPropertyLengthBoundsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/StringPropertyLengthBoundsRuleTest.kt
@@ -2,12 +2,14 @@ package de.zalando.zally.rule.zally
 
 import de.zalando.zally.getOpenApiContextFromContent
 import de.zalando.zally.rule.ZallyAssertions
+import de.zalando.zally.testConfig
 import org.intellij.lang.annotations.Language
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 
 class StringPropertyLengthBoundsRuleTest {
 
-    private val cut = StringPropertyLengthBoundsRule()
+    private val cut = StringPropertyLengthBoundsRule(testConfig)
 
     @Test
     fun `checkStringLengthBounds with bounded string length returns no violations`() {
@@ -176,5 +178,74 @@ class StringPropertyLengthBoundsRuleTest {
             .assertThat(violations)
             .pointersEqualTo("/components/schemas/Thing/properties/theString")
             .descriptionsEqualTo("minLength > maxLength is invalid")
+    }
+
+    @Test
+    fun `checkStringLengthBounds with non-whitelisted format returns min and max violation`() {
+        val format = "password"
+
+        assumeTrue(
+            "test assumes config StringPropertyLengthBoundsRule.formatWhitelist excludes '$format'",
+            format !in cut.formatWhitelist
+        )
+
+        @Language("YAML")
+        val context = getOpenApiContextFromContent(
+            """
+            openapi: 3.0.2
+            info:
+              title: Thing API
+              version: 1.0.0
+            components:
+              schemas:
+                Thing:
+                  type: object
+                  properties:
+                    theString:
+                      type: string
+                      format: $format
+            """.trimIndent()
+        )
+
+        val violations = cut.checkStringLengthBounds(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .pointersEqualTo("/components/schemas/Thing/properties/theString", "/components/schemas/Thing/properties/theString")
+            .descriptionsEqualTo("No minLength defined", "No maxLength defined")
+    }
+
+    @Test
+    fun `checkStringLengthBounds with whitelisted format returns no violations`() {
+        val format = "date-time"
+
+        assumeTrue(
+            "test assumes config StringPropertyLengthBoundsRule.formatWhitelist includes '$format'",
+            format in cut.formatWhitelist
+        )
+
+        @Language("YAML")
+        val context = getOpenApiContextFromContent(
+            """
+            openapi: 3.0.2
+            info:
+              title: Thing API
+              version: 1.0.0
+            components:
+              schemas:
+                Thing:
+                  type: object
+                  properties:
+                    theString:
+                      type: string
+                      format: $format
+            """.trimIndent()
+        )
+
+        val violations = cut.checkStringLengthBounds(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .isEmpty()
     }
 }


### PR DESCRIPTION
StringPropertyLengthBoundsRule can now be configured to suppress violations when:
- format appears in `formatWhitelist`
- pattern is supplied and `patternImpliesLimit`

Default configuration:
```
StringPropertyLengthBoundsRule {
  formatWhitelist: [ date, date-time, uuid, ipv4, ipv6 ]
  patternImpliesLimits: true
}
```

Closes #956 