### PR TITLE
Mapping simplification based on headers

### DIFF
--- a/github-integration/src/main/java/de/zalando/zally/integration/ValidationController.kt
+++ b/github-integration/src/main/java/de/zalando/zally/integration/ValidationController.kt
@@ -15,22 +15,15 @@ import javax.servlet.http.HttpServletRequest
 
 @RestController
 class ValidationController(private val validationService: ValidationService) {
-    private val PULL_REQUEST_EVENT_NAME = "pull_request"
 
     private val log = KotlinLogging.logger {}
 
-    @PostMapping("/github-webhook")
+    @PostMapping("/github-webhook", headers = arrayOf("X-GitHub-Event=pull_request"))
     @ResponseStatus(HttpStatus.ACCEPTED)
     fun validatePullRequest(@RequestBody payload: String,
-                            @RequestHeader(value = "X-GitHub-Event") eventType: String,
                             @RequestHeader(value = "X-Hub-Signature") signature: String) {
 
-        if (eventType != PULL_REQUEST_EVENT_NAME) {
-            log.info("Received unsupported event: {}", eventType)
-            return
-        }
-
-        log.info("Received webhook: {}", eventType)
+        log.info("Received pull request event on webhook")
 
         validationService.validatePullRequest(payload, signature)
 

--- a/github-integration/src/test/java/de/zalando/zally/integration/ValidationControllerIntegrationTest.kt
+++ b/github-integration/src/test/java/de/zalando/zally/integration/ValidationControllerIntegrationTest.kt
@@ -62,12 +62,7 @@ class ValidationControllerIntegrationTest {
 
         val response = restTemplate.postForEntity("/github-webhook", HttpEntity(body, headers), String::class.java)
 
-        assertThat(response.statusCode, `is`(HttpStatus.ACCEPTED))
-
-        githubServer.mock.verifyThatRequest()
-                .havingMethodEqualTo("POST")
-                .havingPath(Matchers.containsString("/statuses/"))
-                .receivedNever()
+        assertThat(response.statusCode, `is`(HttpStatus.NOT_FOUND))
     }
 
     @Test


### PR DESCRIPTION
While browsing the code, I noticed code could be slightly improved - using Spring's mapping annotations, we can define the mapping directly, avoiding a check later on.  