### PR TITLE
UseOpenApiRule is not special

### DIFF
--- a/server/rules.md
+++ b/server/rules.md
@@ -2,6 +2,12 @@
 
 Zally comes with a number of Rule Sets which can be selected and used. The built in rule sets are documented below.
 
+# InternalRuleSet
+
+Internal rules which exist simply for the purpose of reporting fatal
+errors found while attempting to parse the API specification.
+The rules cannot be disabled or configured.
+
 # ZalandoRuleSet
 
 Primarily Zally exists to enforce the various guidelines of the [Zalando RESTful API and Event Scheme Guidelines](http://zalando.github.io/restful-api-guidelines/). Individual rules descriptions won't be repeated here.

--- a/server/src/main/java/de/zalando/zally/apireview/RuleViolation.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/RuleViolation.kt
@@ -25,13 +25,13 @@ class RuleViolation(
     val id: Long = 0
 
     @Column(nullable = false)
-    val name: String = "${result.rule.title} (${result.rule.id})"
+    val name: String = "${result.title} (${result.id})"
 
     @Column(nullable = false)
-    val ruleTitle: String = result.rule.title
+    val ruleTitle: String = result.title
 
     @Column(nullable = false)
-    val ruleUrl: String = result.ruleSet.url(result.rule).toString()
+    val ruleUrl: String = result.url.toString()
 
     @Column(nullable = false)
     val description: String = result.description

--- a/server/src/main/java/de/zalando/zally/rule/Result.kt
+++ b/server/src/main/java/de/zalando/zally/rule/Result.kt
@@ -1,13 +1,13 @@
 package de.zalando.zally.rule
 
 import com.fasterxml.jackson.core.JsonPointer
-import de.zalando.zally.rule.api.Rule
-import de.zalando.zally.rule.api.RuleSet
 import de.zalando.zally.rule.api.Severity
+import java.net.URI
 
 data class Result(
-    val ruleSet: RuleSet,
-    val rule: Rule,
+    val id: String,
+    val url: URI,
+    val title: String,
     val description: String,
     val violationType: Severity,
     val pointer: JsonPointer,

--- a/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
@@ -28,8 +28,9 @@ abstract class RulesValidator<RootT : Any>(val rules: RulesManager) : ApiValidat
             is ParsedWithErrors ->
                 parseResult.violations.map { violation ->
                     Result(
-                        ruleSet = useOpenApiRule.ruleSet,
-                        rule = useOpenApiRule.rule,
+                        id = useOpenApiRule.rule.id,
+                        url = useOpenApiRule.ruleSet.url(useOpenApiRule.rule),
+                        title = useOpenApiRule.rule.title,
                         description = violation.description,
                         violationType = useOpenApiRule.rule.severity,
                         pointer = violation.pointer,
@@ -64,8 +65,8 @@ abstract class RulesValidator<RootT : Any>(val rules: RulesManager) : ApiValidat
             details.method.invoke(details.instance, root)
         } catch (e: InvocationTargetException) {
             throw RuntimeException(
-                "check invocation failed: ruleId=${details.rule.id} " +
-                    "ruleTitle=${details.rule.title} checkName=${details.method.name} reason=${e.targetException}", e
+                "check invocation failed: id=${details.rule.id} " +
+                    "title=${details.rule.title} checkName=${details.method.name} reason=${e.targetException}", e
             )
         }
 
@@ -82,7 +83,15 @@ abstract class RulesValidator<RootT : Any>(val rules: RulesManager) : ApiValidat
                 ignore(root, it.pointer, details.rule.id)
             }
             .map {
-                Result(details.ruleSet, details.rule, it.description, details.check.severity, it.pointer, locator.locate(it.pointer))
+                Result(
+                    id = details.rule.id,
+                    url = details.ruleSet.url(details.rule),
+                    title = details.rule.title,
+                    description = it.description,
+                    violationType = details.check.severity,
+                    pointer = it.pointer,
+                    lines = locator.locate(it.pointer)
+                )
             }
     }
 

--- a/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
@@ -18,7 +18,7 @@ import java.net.URL
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,
-    id = UseOpenApiRule.id,
+    id = "101",
     severity = Severity.MUST,
     title = "Provide API Specification using OpenAPI"
 )
@@ -100,9 +100,5 @@ class UseOpenApiRule(rulesConfig: Config) {
             val schema = ObjectTreeReader().read(schemaUrl)
             JsonSchemaValidator(name.version, schema, schemaRedirects = mapOf(referencedOnlineSchema to localResource))
         }.associateBy { OpenApiVersion.valueOf(it.name.toUpperCase()) }
-    }
-
-    companion object {
-        const val id: String = "101"
     }
 }

--- a/server/src/test/java/de/zalando/zally/apireview/ApiReviewTest.kt
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiReviewTest.kt
@@ -52,5 +52,12 @@ class ApiReviewTest {
     }
 
     private fun result(severity: Severity, pointer: JsonPointer): Result =
-        Result(TestRuleSet(), UseOpenApiRule::class.java.getAnnotation(Rule::class.java), "", severity, pointer)
+        Result(
+            id = UseOpenApiRule::class.java.getAnnotation(Rule::class.java).id,
+            url = TestRuleSet().url(UseOpenApiRule::class.java.getAnnotation(Rule::class.java)),
+            title = UseOpenApiRule::class.java.getAnnotation(Rule::class.java).title,
+            description = "",
+            violationType = severity,
+            pointer = pointer
+        )
 }

--- a/server/src/test/java/de/zalando/zally/apireview/ApiReviewTest.kt
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiReviewTest.kt
@@ -3,14 +3,12 @@ package de.zalando.zally.apireview
 import com.fasterxml.jackson.core.JsonPointer
 import de.zalando.zally.dto.ApiDefinitionRequest
 import de.zalando.zally.rule.Result
-import de.zalando.zally.rule.TestRuleSet
-import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
-import de.zalando.zally.rule.zalando.UseOpenApiRule
 import de.zalando.zally.util.resourceToString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.io.IOException
+import java.net.URI
 import java.util.Arrays.asList
 
 class ApiReviewTest {
@@ -53,10 +51,10 @@ class ApiReviewTest {
 
     private fun result(severity: Severity, pointer: JsonPointer): Result =
         Result(
-            id = UseOpenApiRule::class.java.getAnnotation(Rule::class.java).id,
-            url = TestRuleSet().url(UseOpenApiRule::class.java.getAnnotation(Rule::class.java)),
-            title = UseOpenApiRule::class.java.getAnnotation(Rule::class.java).title,
-            description = "",
+            id = "TestRuleId",
+            url = URI.create("http://rules.example.com/test"),
+            title = "Test Rule Title",
+            description = "Description of test rule",
             violationType = severity,
             pointer = pointer
         )

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.kt
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.kt
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.core.JsonPointer
 import com.fasterxml.jackson.databind.JsonNode
 import de.zalando.zally.rule.TestRuleSet
 import de.zalando.zally.rule.api.Check
-import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.rule.zalando.UseOpenApiRule
 import de.zalando.zally.util.ast.JsonPointers
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -24,8 +22,7 @@ class RestApiTestConfiguration {
     fun rules(): Collection<Any> {
         return listOf(
             TestCheckIsOpenApi3(),
-            TestCheckAlwaysReport3MustViolations(),
-            TestUseOpenApiRule()
+            TestCheckAlwaysReport3MustViolations()
         )
     }
 
@@ -62,16 +59,6 @@ class RestApiTestConfiguration {
                 Violation("TestCheckAlwaysReport3MustViolations #2", JsonPointers.EMPTY),
                 Violation("TestCheckAlwaysReport3MustViolations #3", JsonPointers.EMPTY)
             )
-        }
-    }
-
-    /** Rule used for testing  */
-    @Rule(ruleSet = TestRuleSet::class, id = UseOpenApiRule.id, severity = Severity.MUST, title = "TestUseOpenApiRule")
-    class TestUseOpenApiRule {
-
-        @Check(severity = Severity.HINT)
-        fun validate(@Suppress("UNUSED_PARAMETER") context: Context): Iterable<Violation> {
-            return emptyList()
         }
     }
 }

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.kt
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.kt
@@ -121,7 +121,7 @@ class RestApiViolationsTest : RestApiBaseTest() {
         )
 
         assertThat(response.violations).hasSize(5)
-        assertThat(response.violations[0].title).isEqualTo("TestUseOpenApiRule")
+        assertThat(response.violations[0].title).isEqualTo("Unable to parse API specification")
         assertThat(response.violations[0].description).isEqualTo("attribute openapi is not of type `object`")
         assertThat(response.violations[1].title).isEqualTo("TestCheckIsOpenApi3")
         assertThat(response.externalId).isNotNull()

--- a/server/src/test/java/de/zalando/zally/dto/ViolationsCounterTest.kt
+++ b/server/src/test/java/de/zalando/zally/dto/ViolationsCounterTest.kt
@@ -2,16 +2,14 @@ package de.zalando.zally.dto
 
 import com.fasterxml.jackson.core.JsonPointer
 import de.zalando.zally.rule.Result
-import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Severity.HINT
 import de.zalando.zally.rule.api.Severity.MAY
 import de.zalando.zally.rule.api.Severity.MUST
 import de.zalando.zally.rule.api.Severity.SHOULD
-import de.zalando.zally.rule.zalando.AvoidTrailingSlashesRule
-import de.zalando.zally.rule.zalando.ZalandoRuleSet
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.net.URI
 
 class ViolationsCounterTest {
 
@@ -99,10 +97,10 @@ class ViolationsCounterTest {
     private fun listOfResults(count: Int, severity: Severity): List<Result> {
         return List(count) {
             Result(
-                id = AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java).id,
-                url = ZalandoRuleSet().url(AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java)),
-                title = AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java).title,
-                description = "Test Description",
+                id = "TestRuleId",
+                url = URI.create("http://rules.example.com/test"),
+                title = "Test Rule Title",
+                description = "Description of test rule",
                 violationType = severity,
                 pointer = JsonPointer.compile("/pointer")
             )

--- a/server/src/test/java/de/zalando/zally/dto/ViolationsCounterTest.kt
+++ b/server/src/test/java/de/zalando/zally/dto/ViolationsCounterTest.kt
@@ -97,14 +97,14 @@ class ViolationsCounterTest {
     }
 
     private fun listOfResults(count: Int, severity: Severity): List<Result> {
-        val ruleSet = ZalandoRuleSet()
         return List(count) {
             Result(
-                ruleSet,
-                AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java),
-                "Test Description",
-                severity,
-                JsonPointer.compile("/pointer")
+                id = AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java).id,
+                url = ZalandoRuleSet().url(AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java)),
+                title = AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java).title,
+                description = "Test Description",
+                violationType = severity,
+                pointer = JsonPointer.compile("/pointer")
             )
         }
     }

--- a/server/src/test/java/de/zalando/zally/statistic/RestReviewStatisticsTest.kt
+++ b/server/src/test/java/de/zalando/zally/statistic/RestReviewStatisticsTest.kt
@@ -137,11 +137,12 @@ class RestReviewStatisticsTest : RestApiBaseTest() {
     private fun createRandomViolations(): List<Result> {
         return listOf(
             Result(
-                ZalandoRuleSet(),
-                AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java),
-                "",
-                Severity.MUST,
-                JsonPointer.compile("/pointer")
+                id = AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java).id,
+                url = ZalandoRuleSet().url(AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java)),
+                title = AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java).title,
+                description = "",
+                violationType = Severity.MUST,
+                pointer = JsonPointer.compile("/pointer")
             )
         )
     }

--- a/server/src/test/java/de/zalando/zally/statistic/RestReviewStatisticsTest.kt
+++ b/server/src/test/java/de/zalando/zally/statistic/RestReviewStatisticsTest.kt
@@ -5,15 +5,13 @@ import de.zalando.zally.apireview.ApiReview
 import de.zalando.zally.apireview.RestApiBaseTest
 import de.zalando.zally.dto.ApiDefinitionRequest
 import de.zalando.zally.rule.Result
-import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
-import de.zalando.zally.rule.zalando.AvoidTrailingSlashesRule
-import de.zalando.zally.rule.zalando.ZalandoRuleSet
 import de.zalando.zally.util.ErrorResponse
 import de.zalando.zally.util.TestDateUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.springframework.http.HttpStatus.BAD_REQUEST
+import java.net.URI
 import java.time.LocalDate
 
 class RestReviewStatisticsTest : RestApiBaseTest() {
@@ -137,10 +135,10 @@ class RestReviewStatisticsTest : RestApiBaseTest() {
     private fun createRandomViolations(): List<Result> {
         return listOf(
             Result(
-                id = AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java).id,
-                url = ZalandoRuleSet().url(AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java)),
-                title = AvoidTrailingSlashesRule::class.java.getAnnotation(Rule::class.java).title,
-                description = "",
+                id = "TestRuleId",
+                url = URI.create("http://rules.example.com/test"),
+                title = "Test Rule Title",
+                description = "Description of test rule",
                 violationType = Severity.MUST,
                 pointer = JsonPointer.compile("/pointer")
             )


### PR DESCRIPTION
- Refactored `Result` to reference strings of interest rather than instances of `RuleSet` or `Rule`
- Avoid creating `RuleSet` and `Rule` instances in tests just to build `Result` instances
- `RuleValidator` no longer references a `RuleSet` or `Rule` when parsing fails
- Documented a new `InternalRuleSet`

Closes #851 