### PR TITLE
feat(server): LimitNumberOfResourcesRule supports path whitelist

### DIFF
--- a/server/src/main/resources/rules-config.conf
+++ b/server/src/main/resources/rules-config.conf
@@ -66,6 +66,7 @@ HttpHeadersRule {
 
 LimitNumberOfResourcesRule {
   resource_types_limit: 8
+  path_whitelist: []
 }
 
 LimitNumberOfSubResourcesRule {


### PR DESCRIPTION
- adds a configurable whitelist of paths to ignore when counting and limiting the number of resources (empty by default).

Closes #974 