### PR TITLE
fix(server): AvoidTrailingSlashesRule accepts /

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/zalando/AvoidTrailingSlashesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/AvoidTrailingSlashesRule.kt
@@ -5,7 +5,6 @@ import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.util.PatternUtil
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,
@@ -19,7 +18,15 @@ class AvoidTrailingSlashesRule {
     @Check(severity = Severity.MUST)
     fun validate(context: Context): List<Violation> =
         context.validatePaths(
-            pathFilter = { PatternUtil.hasTrailingSlash(it.key) }
+            pathFilter = { (path, _) ->
+                path.trim().let { trimmed ->
+                    when {
+                        trimmed == "/" -> false
+                        trimmed.endsWith("/") -> true
+                        else -> false
+                    }
+                }
+            }
         ) {
             context.violations(description, it.value)
         }

--- a/server/src/main/java/de/zalando/zally/util/PatternUtil.kt
+++ b/server/src/main/java/de/zalando/zally/util/PatternUtil.kt
@@ -9,8 +9,6 @@ object PatternUtil {
     private val APPLICATION_PROBLEM_JSON_PATTERN = "^application/(problem\\+)?json$".toRegex()
     private val CUSTOM_WITH_VERSIONING_PATTERN = "^\\w+/[-+.\\w]+;v(ersion)?=\\d+$".toRegex()
 
-    fun hasTrailingSlash(input: String): Boolean = input.trim { it <= ' ' }.endsWith("/")
-
     fun isPathVariable(input: String): Boolean = input.matches(PATH_VARIABLE_PATTERN)
 
     fun isApplicationJsonOrProblemJson(mediaType: String): Boolean =

--- a/server/src/test/java/de/zalando/zally/rule/zalando/AvoidTrailingSlashesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/AvoidTrailingSlashesRuleTest.kt
@@ -31,6 +31,7 @@ class AvoidTrailingSlashesRuleTest {
             """
             openapi: '3.0.0'
             paths:
+              /: {}
               /api/test-api: {}
         """.trimIndent()
         )

--- a/server/src/test/java/de/zalando/zally/util/PatternUtilTest.kt
+++ b/server/src/test/java/de/zalando/zally/util/PatternUtilTest.kt
@@ -1,6 +1,5 @@
 package de.zalando.zally.util
 
-import de.zalando.zally.util.PatternUtil.hasTrailingSlash
 import de.zalando.zally.util.PatternUtil.isPathVariable
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -10,12 +9,6 @@ import org.junit.Test
  * Unit tests for patterns utility
  */
 class PatternUtilTest {
-
-    @Test
-    fun checkHasTrailingSlash() {
-        assertTrue(hasTrailingSlash("blah/"))
-        assertFalse(hasTrailingSlash("blah"))
-    }
 
     @Test
     fun checkIsPathVariable() {


### PR DESCRIPTION
- `AvoidTrailingSlashesRule` accepts `/` as special case (presumably as intended).
- Moved logic from `PatternUtil` as it wasn't `Pattern` based and is rule-specific.
- Hopefully made the logic more understandable.

Closes #951 