### PR TITLE
Overhauled MediaTypesRule

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/zalando/MediaTypesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/MediaTypesRule.kt
@@ -5,8 +5,6 @@ import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.util.PatternUtil.isApplicationJsonOrProblemJson
-import de.zalando.zally.util.PatternUtil.isCustomMediaTypeWithVersioning
 
 /**
  * @see "https://opensource.zalando.com/restful-api-guidelines/#172"
@@ -19,6 +17,8 @@ import de.zalando.zally.util.PatternUtil.isCustomMediaTypeWithVersioning
 )
 class MediaTypesRule {
 
+    private val APPLICATION_PROBLEM_JSON_PATTERN = "^application/(problem\\+)?json$".toRegex()
+    private val CUSTOM_WITH_VERSIONING_PATTERN = "^\\w+/[-+.\\w]+;v(ersion)?=\\d+$".toRegex()
     private val description = "Custom media types should only be used for versioning"
 
     @Check(severity = Severity.SHOULD)
@@ -34,4 +34,10 @@ class MediaTypesRule {
 
     private fun isViolatingMediaType(mediaType: String) =
         !isApplicationJsonOrProblemJson(mediaType) && !isCustomMediaTypeWithVersioning(mediaType)
+
+    fun isApplicationJsonOrProblemJson(mediaType: String): Boolean =
+        mediaType.matches(APPLICATION_PROBLEM_JSON_PATTERN)
+
+    fun isCustomMediaTypeWithVersioning(mediaType: String): Boolean =
+        mediaType.matches(CUSTOM_WITH_VERSIONING_PATTERN)
 }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/MediaTypesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/MediaTypesRule.kt
@@ -17,7 +17,7 @@ import de.zalando.zally.rule.api.Violation
 )
 class MediaTypesRule {
 
-    private val APPLICATION_PROBLEM_JSON_PATTERN = "^application/(problem\\+)?json$".toRegex()
+    private val APPLICATION_PROBLEM_JSON_PATTERN = "^application/((problem|json-patch|merge-patch)\\+)?json$".toRegex()
     private val CUSTOM_WITH_VERSIONING_PATTERN = "^\\w+/[-+.\\w]+;v(ersion)?=\\d+$".toRegex()
     private val description = "Custom media types should only be used for versioning"
 

--- a/server/src/main/java/de/zalando/zally/rule/zalando/MediaTypesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/MediaTypesRule.kt
@@ -22,6 +22,8 @@ import io.swagger.v3.oas.models.responses.ApiResponse
 )
 class MediaTypesRule {
 
+    private val versionedMediaType = "^\\w+/[-+.\\w]+;(v|version)=\\d+$".toRegex()
+
     private val description = "Custom media types should only be used for versioning"
 
     private val standardMediaTypes = listOf(
@@ -34,19 +36,15 @@ class MediaTypesRule {
     @Check(severity = Severity.SHOULD)
     fun validate(context: Context): List<Violation> =
         context.api.mediaTypes()
-            .filterNot { (type, _) ->
-                isStandardJsonMediaType(type)
-            }
-            .filterNot { (type, _) ->
-                isVersionedMediaType(type)
-            }
-            .map { (_, value) ->
-                context.violation(description, value)
-            }
+            .filterNot { (type, _) -> isStandardJsonMediaType(type) }
+            .filterNot { (type, _) -> isVersionedMediaType(type) }
+            .map { (_, value) -> context.violation(description, value) }
 
     fun isStandardJsonMediaType(mediaType: String): Boolean = mediaType in standardMediaTypes
 
-    fun isVersionedMediaType(mediaType: String): Boolean = "^\\w+/[-+.\\w]+;(v|version)=\\d+$".toRegex().matches(mediaType)
+    fun isVersionedMediaType(mediaType: String): Boolean {
+        return versionedMediaType.matches(mediaType)
+    }
 
     private fun OpenAPI.mediaTypes(): List<Pair<String, MediaType>> =
         requestBodies().map { it.content }.flatMap { it.mediaTypes() } +

--- a/server/src/main/java/de/zalando/zally/util/PatternUtil.kt
+++ b/server/src/main/java/de/zalando/zally/util/PatternUtil.kt
@@ -6,16 +6,8 @@ package de.zalando.zally.util
 object PatternUtil {
 
     private val PATH_VARIABLE_PATTERN = "\\{.+}$".toRegex()
-    private val APPLICATION_PROBLEM_JSON_PATTERN = "^application/(problem\\+)?json$".toRegex()
-    private val CUSTOM_WITH_VERSIONING_PATTERN = "^\\w+/[-+.\\w]+;v(ersion)?=\\d+$".toRegex()
 
     fun hasTrailingSlash(input: String): Boolean = input.trim { it <= ' ' }.endsWith("/")
 
     fun isPathVariable(input: String): Boolean = input.matches(PATH_VARIABLE_PATTERN)
-
-    fun isApplicationJsonOrProblemJson(mediaType: String): Boolean =
-        mediaType.matches(APPLICATION_PROBLEM_JSON_PATTERN)
-
-    fun isCustomMediaTypeWithVersioning(mediaType: String): Boolean =
-        mediaType.matches(CUSTOM_WITH_VERSIONING_PATTERN)
 }

--- a/server/src/test/java/de/zalando/zally/rule/zalando/MediaTypesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/MediaTypesRuleTest.kt
@@ -16,6 +16,8 @@ class MediaTypesRuleTest {
     fun `isApplicationJsonOrProblemJson for valid input`() {
         assertThat(rule.isApplicationJsonOrProblemJson("application/json")).isTrue()
         assertThat(rule.isApplicationJsonOrProblemJson("application/problem+json")).isTrue()
+        assertThat(rule.isApplicationJsonOrProblemJson("application/json-patch+json")).isTrue()
+        assertThat(rule.isApplicationJsonOrProblemJson("application/merge-patch+json")).isTrue()
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/zalando/MediaTypesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/MediaTypesRuleTest.kt
@@ -5,8 +5,6 @@ import de.zalando.zally.getContextFromFixture
 import de.zalando.zally.getOpenApiContextFromContent
 import de.zalando.zally.rule.DefaultContext
 import de.zalando.zally.rule.api.Violation
-import de.zalando.zally.util.PatternUtil.isApplicationJsonOrProblemJson
-import de.zalando.zally.util.PatternUtil.isCustomMediaTypeWithVersioning
 import io.swagger.v3.oas.models.OpenAPI
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
@@ -16,32 +14,32 @@ class MediaTypesRuleTest {
 
     @Test
     fun `isApplicationJsonOrProblemJson for valid input`() {
-        assertThat(isApplicationJsonOrProblemJson("application/json")).isTrue()
-        assertThat(isApplicationJsonOrProblemJson("application/problem+json")).isTrue()
+        assertThat(rule.isApplicationJsonOrProblemJson("application/json")).isTrue()
+        assertThat(rule.isApplicationJsonOrProblemJson("application/problem+json")).isTrue()
     }
 
     @Test
     fun `isApplicationJsonOrProblemJson for invalid input`() {
-        assertThat(isApplicationJsonOrProblemJson("application/vnd.api+json")).isFalse()
-        assertThat(isApplicationJsonOrProblemJson("application/x.zalando.contract+json")).isFalse()
+        assertThat(rule.isApplicationJsonOrProblemJson("application/vnd.api+json")).isFalse()
+        assertThat(rule.isApplicationJsonOrProblemJson("application/x.zalando.contract+json")).isFalse()
     }
 
     @Test
     fun `isCustomMediaTypeWithVersioning for valid input`() {
-        assertThat(isCustomMediaTypeWithVersioning("application/vnd.api+json;v=12")).isTrue()
-        assertThat(isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;v=34")).isTrue()
-        assertThat(isCustomMediaTypeWithVersioning("application/vnd.api+json;version=123")).isTrue()
-        assertThat(isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;version=345")).isTrue()
+        assertThat(rule.isCustomMediaTypeWithVersioning("application/vnd.api+json;v=12")).isTrue()
+        assertThat(rule.isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;v=34")).isTrue()
+        assertThat(rule.isCustomMediaTypeWithVersioning("application/vnd.api+json;version=123")).isTrue()
+        assertThat(rule.isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;version=345")).isTrue()
     }
 
     @Test
     fun `isCustomMediaTypeWithVersioning for invalid input`() {
-        assertThat(isCustomMediaTypeWithVersioning("application/vnd.api+json")).isFalse()
-        assertThat(isCustomMediaTypeWithVersioning("application/x.zalando.contract+json")).isFalse()
-        assertThat(isCustomMediaTypeWithVersioning("application/vnd.api+json;ver=1")).isFalse()
-        assertThat(isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;v:1")).isFalse()
-        assertThat(isCustomMediaTypeWithVersioning("application/vnd.api+json;version=")).isFalse()
-        assertThat(isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;")).isFalse()
+        assertThat(rule.isCustomMediaTypeWithVersioning("application/vnd.api+json")).isFalse()
+        assertThat(rule.isCustomMediaTypeWithVersioning("application/x.zalando.contract+json")).isFalse()
+        assertThat(rule.isCustomMediaTypeWithVersioning("application/vnd.api+json;ver=1")).isFalse()
+        assertThat(rule.isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;v:1")).isFalse()
+        assertThat(rule.isCustomMediaTypeWithVersioning("application/vnd.api+json;version=")).isFalse()
+        assertThat(rule.isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;")).isFalse()
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/zalando/MediaTypesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/MediaTypesRuleTest.kt
@@ -130,6 +130,33 @@ class MediaTypesRuleTest {
     }
 
     @Test
+    fun `invalid shared components cause violations`() {
+        @Language("YAML")
+        val context = getOpenApiContextFromContent(
+            """
+            openapi: 3.0.0
+            components:
+              requestBodies:
+                NamedRequest:
+                  content:
+                    "application/invalid": {}
+              responses:
+                NamedResponse:
+                  description: description
+                  content:
+                    "application/invalid": {}
+            """.trimIndent())
+
+        val result = rule.validate(context)
+        assertThat(result).hasSameElementsAs(
+            listOf(
+                v("/components/requestBodies/NamedRequest/content/application~1invalid"),
+                v("/components/responses/NamedResponse/content/application~1invalid")
+            )
+        )
+    }
+
+    @Test
     fun `the SPP API generates violations`() {
         val context = getContextFromFixture("api_spp.json")
         val result = rule.validate(context)

--- a/server/src/test/java/de/zalando/zally/rule/zalando/MediaTypesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/MediaTypesRuleTest.kt
@@ -13,35 +13,35 @@ import org.junit.Test
 class MediaTypesRuleTest {
 
     @Test
-    fun `isApplicationJsonOrProblemJson for valid input`() {
-        assertThat(rule.isApplicationJsonOrProblemJson("application/json")).isTrue()
-        assertThat(rule.isApplicationJsonOrProblemJson("application/problem+json")).isTrue()
-        assertThat(rule.isApplicationJsonOrProblemJson("application/json-patch+json")).isTrue()
-        assertThat(rule.isApplicationJsonOrProblemJson("application/merge-patch+json")).isTrue()
+    fun `isStandardJsonMediaType for valid input`() {
+        assertThat(rule.isStandardJsonMediaType("application/json")).isTrue()
+        assertThat(rule.isStandardJsonMediaType("application/problem+json")).isTrue()
+        assertThat(rule.isStandardJsonMediaType("application/json-patch+json")).isTrue()
+        assertThat(rule.isStandardJsonMediaType("application/merge-patch+json")).isTrue()
     }
 
     @Test
-    fun `isApplicationJsonOrProblemJson for invalid input`() {
-        assertThat(rule.isApplicationJsonOrProblemJson("application/vnd.api+json")).isFalse()
-        assertThat(rule.isApplicationJsonOrProblemJson("application/x.zalando.contract+json")).isFalse()
+    fun `isStandardJsonMediaType for invalid input`() {
+        assertThat(rule.isStandardJsonMediaType("application/vnd.api+json")).isFalse()
+        assertThat(rule.isStandardJsonMediaType("application/x.zalando.contract+json")).isFalse()
     }
 
     @Test
-    fun `isCustomMediaTypeWithVersioning for valid input`() {
-        assertThat(rule.isCustomMediaTypeWithVersioning("application/vnd.api+json;v=12")).isTrue()
-        assertThat(rule.isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;v=34")).isTrue()
-        assertThat(rule.isCustomMediaTypeWithVersioning("application/vnd.api+json;version=123")).isTrue()
-        assertThat(rule.isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;version=345")).isTrue()
+    fun `isVersionedMediaType for valid input`() {
+        assertThat(rule.isVersionedMediaType("application/vnd.api+json;v=12")).isTrue()
+        assertThat(rule.isVersionedMediaType("application/x.zalando.contract+json;v=34")).isTrue()
+        assertThat(rule.isVersionedMediaType("application/vnd.api+json;version=123")).isTrue()
+        assertThat(rule.isVersionedMediaType("application/x.zalando.contract+json;version=345")).isTrue()
     }
 
     @Test
-    fun `isCustomMediaTypeWithVersioning for invalid input`() {
-        assertThat(rule.isCustomMediaTypeWithVersioning("application/vnd.api+json")).isFalse()
-        assertThat(rule.isCustomMediaTypeWithVersioning("application/x.zalando.contract+json")).isFalse()
-        assertThat(rule.isCustomMediaTypeWithVersioning("application/vnd.api+json;ver=1")).isFalse()
-        assertThat(rule.isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;v:1")).isFalse()
-        assertThat(rule.isCustomMediaTypeWithVersioning("application/vnd.api+json;version=")).isFalse()
-        assertThat(rule.isCustomMediaTypeWithVersioning("application/x.zalando.contract+json;")).isFalse()
+    fun `isVersionedMediaType for invalid input`() {
+        assertThat(rule.isVersionedMediaType("application/vnd.api+json")).isFalse()
+        assertThat(rule.isVersionedMediaType("application/x.zalando.contract+json")).isFalse()
+        assertThat(rule.isVersionedMediaType("application/vnd.api+json;ver=1")).isFalse()
+        assertThat(rule.isVersionedMediaType("application/x.zalando.contract+json;v:1")).isFalse()
+        assertThat(rule.isVersionedMediaType("application/vnd.api+json;version=")).isFalse()
+        assertThat(rule.isVersionedMediaType("application/x.zalando.contract+json;")).isFalse()
     }
 
     @Test


### PR DESCRIPTION
- Rule accepts `application/json-patch+json` and `application/merge-patch+json` as discussed in #950.
- Rule now checks shared components, not just media types used via paths.
- Logic is self contained and not dependant on `PatternUtil` (it wasn't used by anything else anyway).
- Heavily refactored for increased clarity.

Closes #950 