### PR TITLE
feat(server): Context.violation() requires (nullable) location parameter

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/zalando/ApiAudienceRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/ApiAudienceRule.kt
@@ -1,5 +1,6 @@
 package de.zalando.zally.rule.zalando
 
+import com.fasterxml.jackson.core.JsonPointer
 import com.typesafe.config.Config
 import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Context
@@ -19,14 +20,15 @@ class ApiAudienceRule(rulesConfig: Config) {
     private val noApiAudienceDesc = "API Audience must be provided"
     private val invalidApiAudienceDesc = "API Audience doesn't match $validAudiences"
     private val extensionName = "x-audience"
+    private val extensionPointer = JsonPointer.compile("/info/$extensionName")
 
     @Check(severity = Severity.MUST)
     fun validate(context: Context): Violation? {
         val audience = context.api.info?.extensions?.get(extensionName)
 
         return when (audience) {
-            null, !is String -> context.violation(noApiAudienceDesc)
-            !in validAudiences -> context.violation(invalidApiAudienceDesc)
+            null, !is String -> context.violation(noApiAudienceDesc, extensionPointer)
+            !in validAudiences -> context.violation(invalidApiAudienceDesc, extensionPointer)
             else -> null
         }
     }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/ApiIdentifierRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/ApiIdentifierRule.kt
@@ -1,5 +1,6 @@
 package de.zalando.zally.rule.zalando
 
+import com.fasterxml.jackson.core.JsonPointer
 import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
@@ -19,14 +20,15 @@ class ApiIdentifierRule {
     private val invalidApiIdDesc = "API Identifier doesn't match the pattern $apiIdPattern"
 
     private val extensionName = "x-api-id"
+    private val extensionPointer = JsonPointer.compile("/info/$extensionName")
 
     @Check(severity = Severity.MUST)
     fun validate(context: Context): Violation? {
         val apiId = context.api.info?.extensions?.get(extensionName)
 
         return when {
-            apiId == null || apiId !is String -> context.violation(noApiIdDesc)
-            !apiId.matches(apiIdPattern) -> context.violation(invalidApiIdDesc)
+            apiId == null || apiId !is String -> context.violation(noApiIdDesc, extensionPointer)
+            !apiId.matches(apiIdPattern) -> context.violation(invalidApiIdDesc, extensionPointer)
             else -> null
         }
     }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/ApiMetaInformationRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/ApiMetaInformationRule.kt
@@ -1,5 +1,6 @@
 package de.zalando.zally.rule.zalando
 
+import com.fasterxml.jackson.core.JsonPointer
 import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
@@ -19,13 +20,13 @@ class ApiMetaInformationRule {
     @Check(severity = Severity.MUST)
     fun checkInfoTitle(context: Context): Violation? =
         if (context.api.info?.title.isNullOrBlank()) {
-            context.violation("Title has to be provided")
+            context.violation("Title has to be provided", JsonPointer.compile("/info/title"))
         } else null
 
     @Check(severity = Severity.MUST)
     fun checkInfoDescription(context: Context): Violation? =
         if (context.api.info?.description.isNullOrBlank()) {
-            context.violation("Description has to be provided")
+            context.violation("Description has to be provided", JsonPointer.compile("/info/description"))
         } else null
 
     @Check(severity = Severity.MUST)
@@ -33,9 +34,9 @@ class ApiMetaInformationRule {
         val version = context.api.info?.version
         return when {
             version == null || version.isBlank() ->
-                context.violation("Version has to be provided")
+                context.violation("Version has to be provided", JsonPointer.compile("/info/version"))
             !versionRegex.matches(version) ->
-                context.violation("Version has to follow the Semver rules")
+                context.violation("Version has to follow the Semver rules", JsonPointer.compile("/info/version"))
             else -> null
         }
     }
@@ -43,18 +44,18 @@ class ApiMetaInformationRule {
     @Check(severity = Severity.MUST)
     fun checkContactName(context: Context): Violation? =
         if (context.api.info?.contact?.name.isNullOrBlank()) {
-            context.violation("Contact name has to be provided")
+            context.violation("Contact name has to be provided", JsonPointer.compile("/info/contact/name"))
         } else null
 
     @Check(severity = Severity.MUST)
     fun checkContactUrl(context: Context): Violation? =
         if (context.api.info?.contact?.url.isNullOrBlank()) {
-            context.violation("Contact URL has to be provided")
+            context.violation("Contact URL has to be provided", JsonPointer.compile("/info/contact/url"))
         } else null
 
     @Check(severity = Severity.MUST)
     fun checkContactEmail(context: Context): Violation? =
         if (context.api.info?.contact?.email.isNullOrBlank()) {
-            context.violation("Contact e-mail has to be provided")
+            context.violation("Contact e-mail has to be provided", JsonPointer.compile("/info/contact/email"))
         } else null
 }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/UseOpenApiRule.kt
@@ -13,6 +13,7 @@ import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
 import de.zalando.zally.rule.api.Severity
 import de.zalando.zally.rule.api.Violation
+import de.zalando.zally.util.ast.JsonPointers
 import org.slf4j.LoggerFactory
 import java.net.URL
 
@@ -62,7 +63,7 @@ class UseOpenApiRule(rulesConfig: Config) {
         // -> JSON must start with '{' and end with '}'
         val cleanedUpSource = context.source.trim()
         return if (cleanedUpSource.startsWith("{") && cleanedUpSource.endsWith("}")) {
-            context.violation("must use YAML format")
+            context.violation("must use YAML format", JsonPointers.EMPTY)
         } else {
             null
         }

--- a/server/src/main/java/de/zalando/zally/rule/zalando/VersionInInfoSectionRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/VersionInInfoSectionRule.kt
@@ -1,5 +1,6 @@
 package de.zalando.zally.rule.zalando
 
+import com.fasterxml.jackson.core.JsonPointer
 import de.zalando.zally.rule.api.Check
 import de.zalando.zally.rule.api.Context
 import de.zalando.zally.rule.api.Rule
@@ -20,8 +21,8 @@ class VersionInInfoSectionRule {
     fun checkAPIVersion(context: Context): Violation? {
         val version = context.api.info?.version?.trim()
         return when {
-            version == null -> context.violation("$description: version is missing")
-            !version.matches(versionRegex) -> context.violation("$description: incorrect format")
+            version == null -> context.violation("$description: version is missing", JsonPointer.compile("/info/version"))
+            !version.matches(versionRegex) -> context.violation("$description: incorrect format", JsonPointer.compile("/info/version"))
             else -> null
         }
     }

--- a/server/src/test/java/de/zalando/zally/rule/zalando/SecureWithOAuth2RuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/SecureWithOAuth2RuleTest.kt
@@ -2,6 +2,7 @@ package de.zalando.zally.rule.zalando
 
 import de.zalando.zally.getOpenApiContextFromContent
 import de.zalando.zally.getSwaggerContextFromContent
+import de.zalando.zally.rule.ZallyAssertions
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -60,11 +61,11 @@ class SecureWithOAuth2RuleTest {
         """.trimIndent()
         val context = getOpenApiContextFromContent(content)
 
-        val violation = rule.checkSecuritySchemesOnlyOAuth2IsUsed(context)
+        val violations = rule.checkSecuritySchemesOnlyOAuth2IsUsed(context)
 
-        assertThat(violation).isNotNull
-        assertThat(violation!!.description).isEqualTo("Only OAuth2 is allowed to secure the API")
-        assertThat(violation.pointer.toString()).isEqualTo("/components/securitySchemes")
+        ZallyAssertions.assertThat(violations)
+            .descriptionsEqualTo("Only OAuth2 is allowed to secure the API")
+            .pointersEqualTo("/components/securitySchemes/company-oauth2")
     }
 
     @Test
@@ -75,9 +76,9 @@ class SecureWithOAuth2RuleTest {
         """.trimIndent()
         val context = getOpenApiContextFromContent(content)
 
-        val violation = rule.checkSecuritySchemesOnlyOAuth2IsUsed(context)
+        val violations = rule.checkSecuritySchemesOnlyOAuth2IsUsed(context)
 
-        assertThat(violation).isNull()
+        assertThat(violations).isEmpty()
     }
 
     @Test

--- a/server/zally-rule-api/src/main/kotlin/de/zalando/zally/rule/api/Context.kt
+++ b/server/zally-rule-api/src/main/kotlin/de/zalando/zally/rule/api/Context.kt
@@ -100,7 +100,7 @@ interface Context {
      * @param pointer an existing pointer or null
      * @return the new Violation
      */
-    fun violation(description: String, pointer: JsonPointer? = null): Violation
+    fun violation(description: String, pointer: JsonPointer?): Violation
 
     /**
      * Check whether a location should be ignored by a specific rule.


### PR DESCRIPTION
- Context.violation(String,JsonPointer) no longer defaults 2nd parameter to null
- Specified static JsonPointer for nearly all cases
- Improved dynamic JsonPointer for SecureWithOAuth2Rule.checkSecuritySchemesOnlyOAuth2IsUsed()

Relates to #949