### PR TITLE
Permalinks UI

### DIFF
--- a/server/src/main/java/de/zalando/zally/apireview/ApiReview.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiReview.kt
@@ -25,7 +25,7 @@ import javax.persistence.OneToMany
 class ApiReview(
     request: ApiDefinitionRequest,
     val userAgent: String = "",
-    @Suppress("CanBeParameter") private val apiDefinition: String,
+    @Suppress("CanBeParameter") val apiDefinition: String,
     violations: List<Result> = emptyList(),
     val name: String? = OpenApiHelper.extractApiName(apiDefinition),
     val apiId: String? = OpenApiHelper.extractApiId(apiDefinition),

--- a/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.kt
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
@@ -62,12 +61,11 @@ class ApiViolationsController(
     @ResponseBody
     @GetMapping("/api-violations/{externalId}")
     fun getExistingViolationResponse(
-        @PathVariable(value = "externalId") externalId: UUID,
-        @RequestParam(value = "include_api_definition", required = false, defaultValue = "false") includeApiDefinition: Boolean
+        @PathVariable(value = "externalId") externalId: UUID
     ): ApiDefinitionResponse {
         val review = apiReviewRepository.findByExternalId(externalId) ?: throw ApiReviewNotFoundException()
 
-        return buildApiDefinitionResponse(review, includeApiDefinition)
+        return buildApiDefinitionResponse(review)
     }
 
     private fun retrieveRulesPolicy(request: ApiDefinitionRequest): RulesPolicy = request.ignoreRules
@@ -83,7 +81,7 @@ class ApiViolationsController(
         throw e
     }
 
-    private fun buildApiDefinitionResponse(review: ApiReview, includeApiDefinition: Boolean = false): ApiDefinitionResponse = ApiDefinitionResponse(
+    private fun buildApiDefinitionResponse(review: ApiReview): ApiDefinitionResponse = ApiDefinitionResponse(
         externalId = review.externalId,
         message = serverMessageService.serverMessage(review.userAgent),
         violations = review.ruleViolations.orEmpty().map {
@@ -104,6 +102,6 @@ class ApiViolationsController(
             Severity.MAY to review.mayViolations,
             Severity.HINT to review.hintViolations
         ).map { it.first.name.toLowerCase() to it.second }.toMap(),
-        apiDefinition = if (includeApiDefinition) review.apiDefinition else null
+        apiDefinition = review.apiDefinition
     )
 }

--- a/server/src/main/java/de/zalando/zally/dto/ApiDefinitionResponse.kt
+++ b/server/src/main/java/de/zalando/zally/dto/ApiDefinitionResponse.kt
@@ -6,5 +6,6 @@ data class ApiDefinitionResponse(
     val externalId: UUID? = null,
     val message: String? = null,
     val violations: List<ViolationDTO> = emptyList(),
-    val violationsCount: Map<String, Int> = emptyMap()
+    val violationsCount: Map<String, Int> = emptyMap(),
+    val apiDefinition: String?
 )

--- a/server/src/main/resources/api/zally-api.yaml
+++ b/server/src/main/resources/api/zally-api.yaml
@@ -248,14 +248,6 @@ components:
       schema:
         type: string
         format: uuid
-    IncludeApiDefinition:
-      name: include_api_definition
-      in: query
-      description: Whether to include the API definition in the response
-      required: false
-      schema:
-        type: boolean
-        default: false
 
   schemas:
     LintingRequest:

--- a/server/src/main/resources/api/zally-api.yaml
+++ b/server/src/main/resources/api/zally-api.yaml
@@ -248,6 +248,14 @@ components:
       schema:
         type: string
         format: uuid
+    IncludeApiDefinition:
+      name: include_api_definition
+      in: query
+      description: Whether to include the API definition in the response
+      required: false
+      schema:
+        type: boolean
+        default: false
 
   schemas:
     LintingRequest:
@@ -288,6 +296,9 @@ components:
           description: Custom server message
         violations_count:
           $ref: '#/components/schemas/ViolationsCount'
+        api_definition:
+          type: string
+          description: Specification object in OpenAPI format
 
     SupportedRulesResponse:
       type: object

--- a/server/src/test/java/de/zalando/zally/apireview/ApiViolationsControllerTest.kt
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiViolationsControllerTest.kt
@@ -2,9 +2,9 @@ package de.zalando.zally.apireview
 
 import de.zalando.zally.configuration.JacksonObjectMapperConfiguration
 import de.zalando.zally.dto.ApiDefinitionRequest
+import org.hamcrest.CoreMatchers.hasItem
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.notNullValue
-import org.hamcrest.Matchers.nullValue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -40,7 +41,13 @@ class ApiViolationsControllerTest {
                 .content("{\"api_definition_string\":\"\"}")
         )
             .andExpect(status().isOk)
+            .andExpect(header().exists("Location"))
+            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
             .andExpect(content().string(containsString("https://zalando.github.io/restful-api-guidelines")))
+            .andExpect(jsonPath("$.violations[*].rule_link", hasItem("https://zalando.github.io/restful-api-guidelines/#101")))
+            .andExpect(jsonPath("$.external_id", notNullValue()))
+            .andExpect(jsonPath("$.violations", notNullValue()))
+            .andExpect(jsonPath("$.api_definition", notNullValue()))
     }
 
     @Test
@@ -53,7 +60,7 @@ class ApiViolationsControllerTest {
     }
 
     @Test
-    fun `getExistingViolationResponse with existing responds Ok without api_definition`() {
+    fun `getExistingViolationResponse with existing responds Ok`() {
 
         val location = mvc.perform(
             post("/api-violations")
@@ -65,29 +72,6 @@ class ApiViolationsControllerTest {
 
         mvc.perform(
             get(location.toString())
-                .accept("application/json")
-        )
-            .andExpect(status().isOk)
-            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
-            .andExpect(jsonPath("$.external_id", notNullValue()))
-            .andExpect(jsonPath("$.violations", notNullValue()))
-            .andExpect(jsonPath("$.api_definition", nullValue()))
-    }
-
-    @Test
-    fun `getExistingViolationResponse with existing and include_api_definition responds Ok with api_definition`() {
-
-        val location = mvc.perform(
-            post("/api-violations")
-                .contentType("application/json")
-                .content("{\"api_definition_string\":\"\"}")
-        )
-            .andExpect(status().isOk)
-            .andReturn().response.getHeaderValue("Location")!!
-
-        mvc.perform(
-            get(location.toString())
-                .param("include_api_definition", "true")
                 .accept("application/json")
         )
             .andExpect(status().isOk)

--- a/web-ui/src/client/app/components/__tests__/violations.test.jsx
+++ b/web-ui/src/client/app/components/__tests__/violations.test.jsx
@@ -52,7 +52,6 @@ describe('Violations component', () => {
   test('should render empty list of violation', () => {
     const component = shallow(<Violations violations={[]} />);
     expect(component.find('Violation')).toHaveLength(0);
-    expect(component.find('h3')).toHaveLength(0);
   });
 });
 

--- a/web-ui/src/client/app/components/violations.jsx
+++ b/web-ui/src/client/app/components/violations.jsx
@@ -3,13 +3,21 @@ import { If } from './util.jsx';
 import { Msg } from './msg.jsx';
 import { RuleType } from './rules.jsx';
 import FluidContainer from './fluid-container.jsx';
+import { Link } from 'react-router-dom';
 
 export function Violations(props) {
   return (
     <div>
       <div className="dc-row">
         <div className="dc-column">
-          {props.violations.length ? <h3>VIOLATIONS</h3> : ''}
+          <h3>
+            VIOLATIONS
+            <span style={{ float: 'right' }}>
+              <Link to={'/editor/' + props.externalId} className="dc-link">
+                <i className="dc-icon dc-icon--interactive dc-icon--link" />
+              </Link>
+            </span>
+          </h3>
         </div>
       </div>
       <FluidContainer>
@@ -134,6 +142,7 @@ export function ViolationsResult(props) {
         dataTestId="if-violations"
       >
         <Violations
+          externalId={props.externalId}
           violations={props.violations}
           violationsCount={props.violationsCount}
         />

--- a/web-ui/src/client/app/containers/__tests__/violations-tab.test.jsx.js
+++ b/web-ui/src/client/app/containers/__tests__/violations-tab.test.jsx.js
@@ -43,6 +43,16 @@ describe('ViolationsTab container component', () => {
     expect(component.find('Editor')).toHaveLength(1);
     expect(component.find('Rules')).toHaveLength(0);
   });
+  test('render the Editor tab on /editor/:externalId', () => {
+    const component = mount(
+      <StaticRouter location={{ pathname: '/editor/:externalId' }}>
+        <ViolationsTab authenticated />
+      </StaticRouter>
+    );
+    expect(component.find('URL')).toHaveLength(0);
+    expect(component.find('Editor')).toHaveLength(1);
+    expect(component.find('Rules')).toHaveLength(0);
+  });
   test('render the Rules tab on /rules', () => {
     const component = mount(
       <StaticRouter location={{ pathname: '/rules' }}>

--- a/web-ui/src/client/app/containers/app.jsx
+++ b/web-ui/src/client/app/containers/app.jsx
@@ -14,6 +14,7 @@ export function App(props) {
     Storage,
     getApiViolationsByURL,
     getApiViolationsBySchema,
+    getApiViolationsByExternalId,
     getSupportedRules,
     getFile,
   } = props;
@@ -58,6 +59,7 @@ export function App(props) {
                 getSupportedRules={getSupportedRules}
                 getApiViolationsByURL={getApiViolationsByURL}
                 getApiViolationsBySchema={getApiViolationsBySchema}
+                getApiViolationsByExternalId={getApiViolationsByExternalId}
                 getFile={getFile}
                 Storage={Storage}
                 {...props}

--- a/web-ui/src/client/app/containers/root.jsx
+++ b/web-ui/src/client/app/containers/root.jsx
@@ -18,6 +18,9 @@ export function Root(props) {
         getApiViolationsBySchema={props.RestService.getApiViolationsBySchema.bind(
           props.RestService
         )}
+        getApiViolationsByExternalId={props.RestService.getApiViolationsByExternalId.bind(
+          props.RestService
+        )}
         getFile={props.RestService.getFile.bind(props.RestService)}
         Storage={props.Storage}
         user={props.user}

--- a/web-ui/src/client/app/containers/url.jsx
+++ b/web-ui/src/client/app/containers/url.jsx
@@ -60,6 +60,7 @@ export class URL extends Violations {
           pending={this.state.pending}
           complete={this.state.ajaxComplete}
           errorMsgText={this.state.error}
+          externalId={this.state.externalId}
           violations={this.state.violations}
           successMsgTitle={this.state.successMsgTitle}
           successMsgText={this.state.successMsgText}

--- a/web-ui/src/client/app/containers/violations-tab.jsx
+++ b/web-ui/src/client/app/containers/violations-tab.jsx
@@ -10,6 +10,7 @@ export function ViolationsTab({
   authenticated,
   getApiViolationsByURL,
   getApiViolationsBySchema,
+  getApiViolationsByExternalId,
   getSupportedRules,
   getFile,
   Storage,
@@ -82,6 +83,18 @@ export function ViolationsTab({
               render={props => (
                 <Editor
                   getApiViolations={getApiViolationsBySchema}
+                  getApiViolationsByExternalId={getApiViolationsByExternalId}
+                  Storage={Storage}
+                  {...props}
+                />
+              )}
+            />
+            <Route
+              path="/editor/:externalId"
+              render={props => (
+                <Editor
+                  getApiViolations={getApiViolationsBySchema}
+                  getApiViolationsByExternalId={getApiViolationsByExternalId}
                   Storage={Storage}
                   {...props}
                 />

--- a/web-ui/src/client/app/containers/violations.jsx
+++ b/web-ui/src/client/app/containers/violations.jsx
@@ -6,12 +6,14 @@ export class Violations extends Component {
 
     this.Storage = this.props.Storage;
     this.getApiViolations = this.props.getApiViolations;
+    this.getApiViolationsByExternalId = this.props.getApiViolationsByExternalId;
 
     this.state = {
       error: null,
       pending: false,
       ajaxComplete: false,
       inputValue: '',
+      externalId: null,
       violations: [],
       violationsCount: {
         could: 0,
@@ -34,6 +36,7 @@ export class Violations extends Component {
         this.setState({
           pending: false,
           ajaxComplete: true,
+          externalId: response.external_id,
           violations: response.violations,
           violationsCount: response.violations_count,
         });

--- a/web-ui/src/client/app/services/rest.js
+++ b/web-ui/src/client/app/services/rest.js
@@ -34,6 +34,25 @@ export const RestService = {
     });
   },
 
+  getApiViolationsByExternalId(externalId) {
+    const options = {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    };
+    return client
+      .fetch(
+        `${
+          window.env.ZALLY_API_URL
+        }/api-violations/${externalId}?include_api_definition=true`,
+        options
+      )
+      .then(response => response.json())
+      .catch(response => response.json().then(body => Promise.reject(body)));
+  },
+
   getSupportedRules() {
     const options = {
       method: 'GET',

--- a/web-ui/src/client/app/services/rest.js
+++ b/web-ui/src/client/app/services/rest.js
@@ -46,7 +46,7 @@ export const RestService = {
       .fetch(
         `${
           window.env.ZALLY_API_URL
-        }/api-violations/${externalId}?include_api_definition=true`,
+        }/api-violations/${externalId}`,
         options
       )
       .then(response => response.json())


### PR DESCRIPTION
- UI
  - Violations component now contains a permalink back to view the results again
  - Permalinks take you to the editor page with the definition and validation results loaded
- API
  - `GET /api-violations/{externalId}` now supports an optional `include_api_definition=true`

Example of updated UI:
![image](https://user-images.githubusercontent.com/783694/56029109-978df180-5d11-11e9-9764-1df60392e4dd.png)

Closes #593 