### PR TITLE
manual publish to sonatype oss #964

### DIFF
--- a/server/zally-rule-api/build.gradle.kts
+++ b/server/zally-rule-api/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
     compile("io.swagger.core.v3:swagger-models:2.0.1")
     compile("io.swagger:swagger-models:1.5.2")
-    compile("com.fasterxml.jackson.module:jackson-module-kotlin:2.9+")
+    // 2.9+ is invalid for maven publish
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.8")
 }


### PR DESCRIPTION
Updates:
- switch jackson-module-kotlin:2.9.+ to 2.9.8 (invalid for maven publication)
- variable for version (if using -dev then replace by SNAPSHOT upon maven publication)
- publish main jar, sources and javadoc to sonatype oss (snapshot or staging)
- changed version from 1.0.0 to 1.0.0-dev to avoid publishing a release

publish task is not included in default build and should be triggered by `./gradlew build publish`

allow #964 for manual publication

Notes on local execution:
- commented out dokka (firewall issue when downloading oracle jdk 6)
- commented out swagger downloads (firewall issue)
I executed `./gradlew build publish -x test` (failing tests) and `./gradlew :zally-rule-api:publish :zally-rule-api:build.gradle`
fails on the publication due to firewall (did not configure the proxy; my sample was built/published from travis)

⚠️ please test before integrating because I was - obviously - not able to publish to zalando repository

I did not work on the travis updates for automatic publication