### PR TITLE
Rules to check tags

### DIFF
--- a/server/rules.md
+++ b/server/rules.md
@@ -34,10 +34,23 @@ Supports:
 - schema property names
 - query parameter names
 - path parameter names
+- tag names
+
+## M011: Checks that all operations are tagged
+
+Tags are often used to group operations together in generated
+documentation and so it's useful to ensure that all operations are
+properly tagged. This rule ensures that:
+
+- All operations have at least one tag
+- All tags are defined in the top level `tags:` section
+  (defining order of groups)
+- All defined tags are used
+- All defined tags have a description
 
 ## S005: Do not leave unused definitions
 
-Unused definitions cause confusion and should be avioded.
+Unused definitions cause confusion and should be avoided.
 
 ## S006: Define bounds for numeric properties
 

--- a/server/src/main/java/de/zalando/zally/rule/zally/CaseCheckerRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/CaseCheckerRule.kt
@@ -55,6 +55,15 @@ class CaseCheckerRule(config: Config) {
         checker.checkHeadersNames(context)
 
     /**
+     * Check that tag names match the configured requirements.
+     * @param context The specification context to check.
+     * @return a list of Violations, possibly empty.
+     */
+    @Check(severity = Severity.MUST)
+    fun checkTagNames(context: Context): List<Violation> =
+        checker.checkTagNames(context)
+
+    /**
      * Check that path segments match the configured requirements.
      * @param context The specification context to check.
      * @return a list of Violations, possibly empty.

--- a/server/src/main/java/de/zalando/zally/rule/zally/TagAllOperationsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/TagAllOperationsRule.kt
@@ -1,0 +1,26 @@
+package de.zalando.zally.rule.zally
+
+import de.zalando.zally.rule.api.Check
+import de.zalando.zally.rule.api.Context
+import de.zalando.zally.rule.api.Rule
+import de.zalando.zally.rule.api.Severity
+import de.zalando.zally.rule.api.Violation
+
+@Rule(
+    ruleSet = ZallyRuleSet::class,
+    id = "M011",
+    severity = Severity.MUST,
+    title = "Tag all operations"
+)
+class TagAllOperationsRule {
+
+    @Check(severity = Severity.MUST)
+    fun checkOperationsAreTagged(context: Context): List<Violation> =
+        context.validateOperations { (_, operation) ->
+            when {
+                operation == null -> emptyList()
+                operation.tags.orEmpty().isEmpty() -> context.violations("Operation has no tag", operation)
+                else -> emptyList<Violation>()
+            }
+        }
+}

--- a/server/src/main/java/de/zalando/zally/rule/zally/TagAllOperationsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/TagAllOperationsRule.kt
@@ -38,6 +38,22 @@ class TagAllOperationsRule {
     }
 
     @Check(severity = Severity.MUST)
+    fun checkDefinedTagsAreUsed(context: Context): List<Violation> {
+        val used = context.api.paths?.values
+            .orEmpty()
+            .flatMap { it.readOperations() }
+            .flatMap { it?.tags.orEmpty() }
+            .toSet()
+
+        return context.api.tags
+            .orEmpty()
+            .filter { it.name !in used }
+            .map {
+                context.violation("Tag '${it.name}' is not used", it)
+            }
+    }
+
+    @Check(severity = Severity.MUST)
     fun checkDefinedTagsAreDescribed(context: Context): List<Violation> = context.api.tags
         .orEmpty()
         .filter { it.description == null }

--- a/server/src/main/java/de/zalando/zally/rule/zally/TagAllOperationsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/TagAllOperationsRule.kt
@@ -36,4 +36,12 @@ class TagAllOperationsRule {
             }
         }
     }
+
+    @Check(severity = Severity.MUST)
+    fun checkDefinedTagsAreDescribed(context: Context): List<Violation> = context.api.tags
+        .orEmpty()
+        .filter { it.description == null }
+        .map {
+            context.violation("Tag '${it.name}' has no description", it)
+        }
 }

--- a/server/src/main/java/de/zalando/zally/rule/zally/TagAllOperationsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zally/TagAllOperationsRule.kt
@@ -23,4 +23,17 @@ class TagAllOperationsRule {
                 else -> emptyList<Violation>()
             }
         }
+
+    @Check(severity = Severity.MUST)
+    fun checkOperationTagsAreDefined(context: Context): List<Violation> {
+        val defined = context.api.tags
+            .map { it.name }
+            .toSet()
+
+        return context.validateOperations { (_, operation) ->
+            operation?.tags.orEmpty().filter { it !in defined }.flatMap {
+                context.violations("Tag '$it' is not defined", operation)
+            }
+        }
+    }
 }

--- a/server/src/main/resources/rules-config.conf
+++ b/server/src/main/resources/rules-config.conf
@@ -8,6 +8,7 @@ CaseChecker {
     COBOL-CASE:             "[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*"
     hyphenated-Camel-Case:  "[a-z][a-z0-9]*(?:-[A-Z0-9]+[a-z0-9]*)*"
     Hyphenated-Pascal-Case: "[A-Z]+[a-z0-9]*(?:-[A-Z0-9]+[a-z0-9]*)*"
+    Title Case:              "([A-Z][^\\s]*\\s?)+"
   }
   pathSegments {
     allow: [
@@ -34,6 +35,11 @@ CaseChecker {
   headerNames {
     allow: [
       ${CaseChecker.cases.Hyphenated-Pascal-Case}
+    ]
+  }
+  tagNames {
+    allow: [
+      ${CaseChecker.cases.Title Case}
     ]
   }
   discriminatorValues {

--- a/server/src/test/java/de/zalando/zally/rule/CaseCheckerParameterizedTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/CaseCheckerParameterizedTest.kt
@@ -55,6 +55,10 @@ class CaseCheckerParameterizedTest(private val param: TestParam) {
                 "Hyphenated-Pascal-Case",
                 listOf("Test-Case", "X-Flow-Id", "ETag", "Test-Case1234", "Test-Case-1234"),
                 listOf("test-Case", "TestCase", "testCase", "1234-Test-Case")
+            ) + parameters(
+                "Title Case",
+                listOf("Test Case", "TestCase", "Test-Case"),
+                listOf("test-Case")
             )
 
             val excess = parameters.map { it.case }.toSet() - checker.cases.keys

--- a/server/src/test/java/de/zalando/zally/rule/zally/CaseCheckerRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/CaseCheckerRuleTest.kt
@@ -148,6 +148,31 @@ class CaseCheckerRuleTest {
     }
 
     @Test
+    fun `checkTagNames returns violations`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent(
+            """
+            swagger: '2.0'
+            tags:
+              - name: iNvAlId!
+            paths:
+              /things:
+                get:
+                  tags:
+                    - iNvAlId!
+                  description: Get things
+            """.trimIndent()
+        )
+
+        val violations = cut.checkTagNames(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .descriptionsAllMatch("Tag 'iNvAlId!' does not match .*".toRegex())
+            .pointersEqualTo("/tags/0", "/paths/~1things/get/tags")
+    }
+
+    @Test
     fun `checkPathSegments returns violations`() {
         @Language("YAML")
         val context = getSwaggerContextFromContent(

--- a/server/src/test/java/de/zalando/zally/rule/zally/TagAllOperationsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/TagAllOperationsRuleTest.kt
@@ -14,6 +14,7 @@ class TagAllOperationsRuleTest {
     private fun TagAllOperationsRule.checkAll(context: Context): List<Violation> =
         checkOperationsAreTagged(context) +
             checkOperationTagsAreDefined(context) +
+            checkDefinedTagsAreUsed(context) +
             checkDefinedTagsAreDescribed(context)
 
     @Test
@@ -105,6 +106,25 @@ class TagAllOperationsRuleTest {
             .assertThat(violations)
             .pointersEqualTo("/paths/~1things/post")
             .descriptionsEqualTo("Tag 'Things' is not defined")
+    }
+
+    @Test
+    fun `checkDefinedTagsAreUsed with unused tag returns violation`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent(
+            """
+            swagger: '2.0'
+            tags:
+              - name: Things
+            """.trimIndent()
+        )
+
+        val violations = cut.checkDefinedTagsAreUsed(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .pointersEqualTo("/tags/0")
+            .descriptionsEqualTo("Tag 'Things' is not used")
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/zally/TagAllOperationsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/TagAllOperationsRuleTest.kt
@@ -13,7 +13,8 @@ class TagAllOperationsRuleTest {
 
     private fun TagAllOperationsRule.checkAll(context: Context): List<Violation> =
         checkOperationsAreTagged(context) +
-            checkOperationTagsAreDefined(context)
+            checkOperationTagsAreDefined(context) +
+            checkDefinedTagsAreDescribed(context)
 
     @Test
     fun `checkAll with 'noop' spec returns no violations`() {
@@ -39,6 +40,7 @@ class TagAllOperationsRuleTest {
             swagger: '2.0'
             tags:
               - name: Things
+                description: Operations dealing with Things
             paths:
               '/things':
                 post:
@@ -103,5 +105,24 @@ class TagAllOperationsRuleTest {
             .assertThat(violations)
             .pointersEqualTo("/paths/~1things/post")
             .descriptionsEqualTo("Tag 'Things' is not defined")
+    }
+
+    @Test
+    fun `checkDefinedTagsAreDescribed without tag description returns violation`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent(
+            """
+            swagger: '2.0'
+            tags:
+              - name: Things
+            """.trimIndent()
+        )
+
+        val violations = cut.checkDefinedTagsAreDescribed(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .pointersEqualTo("/tags/0")
+            .descriptionsEqualTo("Tag 'Things' has no description")
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/zally/TagAllOperationsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/TagAllOperationsRuleTest.kt
@@ -1,0 +1,74 @@
+package de.zalando.zally.rule.zally
+
+import de.zalando.zally.getSwaggerContextFromContent
+import de.zalando.zally.rule.ZallyAssertions
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class TagAllOperationsRuleTest {
+
+    private val cut = TagAllOperationsRule()
+
+    @Test
+    fun `checkOperationsAreTagged with no operations returns no violations`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent(
+            """
+            swagger: '2.0'
+            """.trimIndent()
+        )
+
+        val violations = cut.checkOperationsAreTagged(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .isEmpty()
+    }
+
+    @Test
+    fun `checkOperationsAreTagged with well tagged operations returns no violations`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent(
+            """
+            swagger: '2.0'
+            paths:
+              '/things':
+                post:
+                  tags:
+                    - Things
+                  responses:
+                    200:
+                      description: Done
+            """.trimIndent()
+        )
+
+        val violations = cut.checkOperationsAreTagged(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .isEmpty()
+    }
+
+    @Test
+    fun `checkOperationsAreTagged with untagged operations returns violations`() {
+        @Language("YAML")
+        val context = getSwaggerContextFromContent(
+            """
+            swagger: '2.0'
+            paths:
+              '/things':
+                post:
+                  responses:
+                    200:
+                      description: Done
+            """.trimIndent()
+        )
+
+        val violations = cut.checkOperationsAreTagged(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .pointersEqualTo("/paths/~1things/post")
+            .descriptionsEqualTo("Operation has no tag")
+    }
+}

--- a/server/src/test/resources/fixtures/no_must_violations.yaml
+++ b/server/src/test/resources/fixtures/no_must_violations.yaml
@@ -89,6 +89,18 @@ parameters:
       $ref: '#/definitions/CrawledAPIDefinition'
     required: true
 
+tags:
+  - name: APIs
+    description: Description of APIs
+  - name: Applications
+    description: Description of Applications
+  - name: Definitions
+    description: Description of Definitions
+  - name: Deployments
+    description: Description of Deployments
+  - name: Versions
+    description: Description of Versions
+
 paths:
   '/apis':
     get:


### PR DESCRIPTION
- Add `CaseCheckerRule.checkTagNames()`
  - implements "Tag names are Title Case"
- Add `TagAllOperationsRule`
  - All operations have at least one tag
  - All tags are defined in the top level `tags:` section (defining order of groups)
  - All defined tags are used
  - All defined tags have a description
- Fix typo "avioded" in rules.md

Closes #1010