### PR TITLE
chore #1030: support access to /api-violations/{externalId}

### DIFF
--- a/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.kt
+++ b/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.kt
@@ -48,7 +48,7 @@ class OAuthConfiguration : ResourceServerConfigurerAdapter() {
             .regexMatchers("/health/?").permitAll()
             .regexMatchers(
                 "/metrics/?(\\?.*)?",
-                "/api-violations/?(\\?)?",
+                "/api-violations/?(\\?.*)?",
                 "/supported-rules/?(\\?.*)?",
                 "/review-statistics/?(\\?.*)?"
             )


### PR DESCRIPTION
Closes #1030 