### PR TITLE
chore #1030: support access to /api-violations/{externalId}

### DIFF
--- a/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.kt
+++ b/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.kt
@@ -48,7 +48,7 @@ class OAuthConfiguration : ResourceServerConfigurerAdapter() {
             .regexMatchers("/health/?").permitAll()
             .regexMatchers(
                 "/metrics/?(\\?.*)?",
-                "/api-violations/?(\\?.*)?",
+                "/api-violations/?([a-z0-9-]+/?)?(\\?)?",
                 "/supported-rules/?(\\?.*)?",
                 "/review-statistics/?(\\?.*)?"
             )

--- a/server/src/test/java/de/zalando/zally/configuration/PathMatchersTest.kt
+++ b/server/src/test/java/de/zalando/zally/configuration/PathMatchersTest.kt
@@ -46,9 +46,25 @@ class PathMatchersTest {
         assertThat(matcher.matches(request("/metrics/"))).isTrue()
         assertThat(matcher.matches(request("/metrics/?"))).isTrue()
         assertThat(matcher.matches(request("/metrics/?"))).isTrue()
+        assertThat(matcher.matches(request("/metrics/ab"))).isFalse()
         assertThat(matcher.matches(request("/metrics?parameter=value"))).isTrue()
         assertThat(matcher.matches(request("/metrics/?parameter=value"))).isTrue()
         assertThat(matcher.matches(request("/metrics-resource/?parameter=value"))).isFalse()
+    }
+
+    @Test
+    fun `regex matcher matches allows sub-paths`() {
+        val matcher = RegexRequestMatcher("/api-violations/?([a-z0-9-]+/?)?(\\?)?", null)
+        assertThat(matcher.matches(request("/api-violations"))).isTrue()
+        assertThat(matcher.matches(request("/api-violations?"))).isTrue()
+        assertThat(matcher.matches(request("/api-violations/"))).isTrue()
+        assertThat(matcher.matches(request("/api-violations/?"))).isTrue()
+        assertThat(matcher.matches(request("/api-violations/?"))).isTrue()
+        assertThat(matcher.matches(request("/api-violations/dcb5a97e-3586-44fc-b40c-90e209cf2e73"))).isTrue()
+        assertThat(matcher.matches(request("/api-violations/dcb5a97e-3586-44fc-b40c-90e209cf2e73/"))).isTrue()
+        assertThat(matcher.matches(request("/api-violations?parameter=value"))).isFalse()
+        assertThat(matcher.matches(request("/api-violations/?parameter=value"))).isFalse()
+        assertThat(matcher.matches(request("/api-violations-resource/?parameter=value"))).isFalse()
     }
 
     @Test


### PR DESCRIPTION
Closes #1030 