### PR TITLE
Use formatters for error messages.

### DIFF
--- a/cli/zally/commands/lint.go
+++ b/cli/zally/commands/lint.go
@@ -57,7 +57,7 @@ func lint(c *cli.Context) error {
 
 	numberOfMustViolations := len(violations.Must())
 	if numberOfMustViolations > 0 {
-		return domain.NewAppError(fmt.Errorf("Failing because: %d must violation(s) found",
+		return domain.NewAppError(fmt.Errorf(formatter.FormatErrorMessage("Failing because: %d 'MUST' violation(s) found"),
 			numberOfMustViolations), domain.ValidationError)
 	}
 

--- a/cli/zally/commands/lint_test.go
+++ b/cli/zally/commands/lint_test.go
@@ -154,7 +154,7 @@ func TestLint(t *testing.T) {
 
 		err := lint(getLintContext(testServer.URL, []string{"testdata/minimal_swagger.json"}, "markdown"))
 
-		tests.AssertEquals(t, "Failing because: 1 must violation(s) found", err.Error())
+		tests.AssertEquals(t, "\nFailing because: 1 'MUST' violation(s) found\n\n", err.Error())
 	})
 }
 

--- a/cli/zally/utils/formatters/formatter.go
+++ b/cli/zally/utils/formatters/formatter.go
@@ -9,4 +9,5 @@ type Formatter interface {
 	FormatMessage(message string) string
 	FormatServerMessage(message string) string
 	FormatRule(rule *domain.Rule) string
+	FormatErrorMessage(message string) string
 }

--- a/cli/zally/utils/formatters/markdown_formatter.go
+++ b/cli/zally/utils/formatters/markdown_formatter.go
@@ -63,6 +63,10 @@ func (f *MarkdownFormatter) FormatServerMessage(message string) string {
 	return ""
 }
 
+func (f *MarkdownFormatter) FormatErrorMessage(message string) string {
+	return f.FormatMessage(message)
+}
+
 func (f *MarkdownFormatter) formatViolation(violation *domain.Violation) string {
 	var buffer bytes.Buffer
 
@@ -76,7 +80,7 @@ func (f *MarkdownFormatter) formatViolation(violation *domain.Violation) string 
 			fmt.Fprintf(&buffer, "- %s\n", path)
 		}
 	}
-	
+
 	fmt.Fprintf(&buffer, "\n")
 
 	return buffer.String()

--- a/cli/zally/utils/formatters/markdown_formatter_test.go
+++ b/cli/zally/utils/formatters/markdown_formatter_test.go
@@ -168,7 +168,7 @@ func TestMarkdownFormatViolation(t *testing.T) {
 
 		tests.AssertEquals(t, expectedResult, actualResult)
 	})
-	
+
 }
 
 func TestMarkdownFormatHeader(t *testing.T) {
@@ -186,4 +186,20 @@ func TestMarkdownFormatHeader(t *testing.T) {
 		result := formatter.formatHeader("")
 		tests.AssertEquals(t, "", result)
 	})
+}
+
+func TestMarkdownFormatErrorMessage(t *testing.T) {
+	var formatter MarkdownFormatter
+	t.Run("Formats nothing when no message", func(t *testing.T) {
+		answer := formatter.FormatErrorMessage("")
+		tests.AssertEquals(t, "", answer)
+	})
+
+	t.Run("Formats error message when specified", func(t *testing.T) {
+		actualResult := formatter.FormatErrorMessage("Error")
+		expectedResult := "\nError\n\n"
+
+		tests.AssertEquals(t, expectedResult, actualResult)
+	})
+
 }

--- a/cli/zally/utils/formatters/pretty_formatter.go
+++ b/cli/zally/utils/formatters/pretty_formatter.go
@@ -74,6 +74,13 @@ func (f *PrettyFormatter) FormatServerMessage(message string) string {
 	return ""
 }
 
+func (f *PrettyFormatter) FormatErrorMessage(message string) string {
+	if message != "" {
+		return fmt.Sprintf("\n%s", f.colorizer.auroraInstance.Red(message))
+	}
+	return ""
+}
+
 func (f *PrettyFormatter) formatHeader(header string) string {
 	if len(header) == 0 {
 		return ""

--- a/cli/zally/utils/formatters/pretty_formatter_test.go
+++ b/cli/zally/utils/formatters/pretty_formatter_test.go
@@ -180,7 +180,7 @@ func TestTextFormatMessage(t *testing.T) {
 	prettyFormatter := NewPrettyFormatter(NewPrettyColorizer(false))
 
 	t.Run("Formats nothing when no message", func(t *testing.T) {
-		actualResult := prettyFormatter.FormatServerMessage("")
+		actualResult := prettyFormatter.FormatMessage("")
 
 		tests.AssertEquals(t, "", actualResult)
 	})
@@ -207,5 +207,19 @@ func TestTextFormatServerMessage(t *testing.T) {
 		expectedResult := "\n\nServer message:\n===============\n\nHello world!\n\n\n"
 
 		tests.AssertEquals(t, expectedResult, actualResult)
+	})
+}
+
+func TestFormatErrorMessage(t *testing.T) {
+	formatter := NewPrettyFormatter(NewPrettyColorizer(false))
+
+	t.Run("Formats nothing when no message", func(t *testing.T) {
+		actualResult := formatter.FormatErrorMessage("")
+		tests.AssertEquals(t, "", actualResult)
+	})
+
+	t.Run("Formats error message", func(t *testing.T) {
+		actualResult := formatter.FormatErrorMessage("Error message")
+		tests.AssertEquals(t, "\nError message", actualResult)
 	})
 }


### PR DESCRIPTION
* Extend supported formatters with error messages format. `pretty` formatter will print error message using red color.
* Change `lint` command code to use chosen formatter when printing error message.

Fixes #694.