### PR TITLE
fix for issue #1075 - Update Dockerfile

### DIFF
--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/node:10.15.3-45
+FROM node:12
 
 MAINTAINER "http://zalando.github.io/"
 


### PR DESCRIPTION
This fixes issue #1075

The previous version of node referenced in the web-ui Dockerfile may have had outdated packages needed by the web-ui, as attempting to deploy the web-ui via Docker resulted in the web-ui not rendering the page.  Once I updated node to v12, the web-ui properly rendered the Zally editor.