### PR TITLE
Fix #1079. Build webapp inside a java container.

### DIFF
--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# This script builds Zally server and Zally Web UI and starts the components via docker-compose
+# This script starts the Zally components via docker-compose:
+#  the server component is separately built inside its own container.
+
 
 set -ex
 
@@ -12,9 +14,6 @@ popd > /dev/null
 SERVER_DIR=${SCRIPT_DIR}/server
 WEB_UI_DIR=${SCRIPT_DIR}/web-ui
 GITHUB_INTEGRATION_DIR=${SCRIPT_DIR}/github_integration
-
-# Build server
-cd ${SERVER_DIR} && ./gradlew build -x test
 
 # Build web ui
 cd ${WEB_UI_DIR} && yarn && yarn build

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,9 +1,18 @@
+#
+# Build the java application in a separate container.
+#
+FROM registry.opensource.zalan.do/stups/openjdk:latest as builder
+COPY . /src
+WORKDIR /src
+RUN ./gradlew build --info
+
+
 FROM registry.opensource.zalan.do/stups/openjdk:latest
 
 MAINTAINER "http://zalando.github.io/"
 
 COPY src/main/resources/api/zally-api.yaml /zalando-apis/zally-api.yaml
-COPY build/libs/zally.jar /
+COPY --from=builder /src/build/libs/zally.jar /
 
 EXPOSE 8080
 


### PR DESCRIPTION
## This PR

Builds the gradle application inside a container and avoids running or installing
anything inside the docker machine.

## It's done

Via a multi-stage build. https://docs.docker.com/develop/develop-images/multistage-build/