### PR TITLE
Add 'Idempotency-Key' header as per rule 230

### DIFF
--- a/server/src/main/resources/rules-config.conf
+++ b/server/src/main/resources/rules-config.conf
@@ -186,6 +186,7 @@ ProprietaryHeadersRule {
     "Forwarded",
     "From",
     "Host",
+    "Idempotency-Key",
     "If-Match",
     "If-Modified-Since",
     "If-None-Match",


### PR DESCRIPTION
Adding `Idempotency-Key` header as per: [MAY consider to support Idempotency-Key header [230]](https://opensource.zalando.com/restful-api-guidelines/#230), following the example of the `Prefer` header (see [MAY consider to support Prefer header to handle processing preferences [181]](https://opensource.zalando.com/restful-api-guidelines/#181)).

Neither `Idempotency-Key` or `Prefer` are standard headers as per the list linked in [rule 133](https://opensource.zalando.com/restful-api-guidelines/#133), but are explicitly allowed by their respective rules, so they might belong in a new config variable separate to `standard_request_headers`.

Fixes: #1104