### PR TITLE
Sign `zally` artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,12 @@ So why should you choose Zally?
 ## License
 
 MIT license with an exception. See [license file](LICENSE).
+
+## Publish
+
+### Prerequisites
+
+* [Signing plugin](https://docs.gradle.org/current/userguide/signing_plugin.htm) configured
+* `OSSRH_JIRA_USERNAME` and `OSSRH_JIRA_PASSWORD` to access [Maven Central Repo](https://oss.sonatype.org/) are 
+configured in `$HOME/.gradle/gradle.properties` 
+ 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "7.2.1"
     id("org.jetbrains.dokka") version "0.10.0"
     id("maven-publish")
+    signing
 }
 
 allprojects {
@@ -128,6 +129,10 @@ allprojects {
             }
         }
     }
+}
+
+signing {
+    sign(publishing.publications["mavenJava"])
 }
 
 dependencyManagement {


### PR DESCRIPTION
* Add [signing plugin](https://docs.gradle.org/current/userguide/signing_plugin.htm) which signs artifacts before publishing to Maven Central
* Update `readme` with information how to configure publish step

Related to #964