### PR TITLE
Make it easy to start the server standalone. Refs #1134

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ and database) by executing:
 ```bash
 ./build-and-run.sh
 ```
-
 Web UI is accessible on `http://localhost:8080`; Zally server on `http://localhost:8000`
+
+**Alternatively** , you can run only the server component of zally by executing the `startlocalserver.sh` script under `server/`
+
+You can modify the script if you want to reconfigure the port number or the database details
 
 ## Documentation and Manuals
 

--- a/server/startlocalserver.sh
+++ b/server/startlocalserver.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+export SPRING_PROFILES_ACTIVE=dev
+export SPRING_DATASOURCE_URL=jdbc:postgresql://postgres.local:5432/zally
+export SPRING_DATASOURCE_USERNAME=postgres
+export SPRING_DATASOURCE_PASSWORD=postgres
+export MANAGEMENT_PORT=7979
+export TOKEN_INFO_URI=https://url.not.set
+
+docker run -d -p 5432:5432 --env POSTGRES_PASSWORD=postgres --env POSTGRES_DB=zally postgres:9.6
+./gradlew clean
+./gradlew bootRun
+
+
+#Optional: Add an entry for `postgres.local` to /etc/hosts pointing to localhost
+#echo "127.0.0.1  postgres.local" >> /etc/hosts
+
+


### PR DESCRIPTION
Currently, the server is started as a part of the `docker-compose`
command, which downloads docker images and runs a lot of other gradle
tasks, lengthening the development cycle.
Add a new script which will run the pre-requisite postgres db as a
docker image, expose the DB Port to the application and run the
`bootRun` task, which starts the server.

The `web-ui` can be run separately to use the `web-ui` for linting APIs