### PR TITLE
fix(server): StringPropertyLengthBoundsRule ignores enum strings #1137

### DIFF
--- a/server/zally-ruleset-zally/src/main/kotlin/de/zalando/zally/ruleset/zally/StringPropertyLengthBoundsRule.kt
+++ b/server/zally-ruleset-zally/src/main/kotlin/de/zalando/zally/ruleset/zally/StringPropertyLengthBoundsRule.kt
@@ -33,6 +33,7 @@ class StringPropertyLengthBoundsRule(config: Config) {
                     schema.type != "string" -> false
                     schema.format in formatWhitelist -> false
                     schema.pattern != null && patternImpliesLimits -> false
+                    schema.enum != null -> false
                     else -> true
                 }
             }

--- a/server/zally-ruleset-zally/src/test/kotlin/de/zalando/zally/ruleset/zally/StringPropertyLengthBoundsRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/de/zalando/zally/ruleset/zally/StringPropertyLengthBoundsRuleTest.kt
@@ -280,4 +280,31 @@ class StringPropertyLengthBoundsRuleTest {
             .assertThat(violations)
             .isEmpty()
     }
+
+    @Test
+    fun `checkStringLengthBounds with enum returns no violations`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+            """
+            openapi: 3.0.2
+            info:
+              title: Thing API
+              version: 1.0.0
+            components:
+              schemas:
+                Thing:
+                  type: object
+                  properties:
+                    theString:
+                      type: string
+                      enum: [foo, bar]
+            """.trimIndent()
+        )
+
+        val violations = cut.checkStringLengthBounds(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .isEmpty()
+    }
 }


### PR DESCRIPTION
- No violations created when string property is an enum

Closes #1137 