### PR TITLE
fix: docker build (#1144)

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,7 +11,7 @@ FROM registry.opensource.zalan.do/stups/openjdk:latest
 
 MAINTAINER "http://zalando.github.io/"
 
-COPY src/main/resources/api/zally-api.yaml /zalando-apis/zally-api.yaml
+COPY zally-server/src/main/resources/api/zally-api.yaml /zalando-apis/zally-api.yaml
 COPY --from=builder /src/zally-server/build/libs/zally-server.jar /
 
 EXPOSE 8080


### PR DESCRIPTION
fixes #1144.

After server refactoring #1116 the Docker build failed because of moved api specification.