### PR TITLE
fix(server): Correctly parse extension JsonPointers in ReverseAstBuilder (#1148)

### DIFF
--- a/server/zally-core/src/main/kotlin/de/zalando/zally/core/ast/ReverseAstBuilder.kt
+++ b/server/zally-core/src/main/kotlin/de/zalando/zally/core/ast/ReverseAstBuilder.kt
@@ -97,9 +97,14 @@ class ReverseAstBuilder<T : Any> internal constructor(root: T) {
                         // We must not use the method name but re-use the current pointer.
                         nodes.push(Node(value, pointer, marker, /* skip */true))
                     } else {
-                        nodes.push(Node(value, pointer + m.name
-                                .removePrefix("get")
-                                .decapitalize().toEscapedJsonPointer(), marker))
+                        // Do not add extension names to the JsonNode path
+                        val nextPath = m.name
+                            .takeIf { it !in this.extensionMethodNames }
+                            ?.removePrefix("get")
+                            ?.decapitalize()
+                            ?: ""
+
+                        nodes.push(Node(value, pointer + nextPath.toEscapedJsonPointer(), marker))
                     }
                 }
             } catch (e: ReflectiveOperationException) {

--- a/server/zally-core/src/test/kotlin/de/zalando/zally/core/OpenApiRulesValidatorTest.kt
+++ b/server/zally-core/src/test/kotlin/de/zalando/zally/core/OpenApiRulesValidatorTest.kt
@@ -1,0 +1,78 @@
+package de.zalando.zally.core
+
+import com.fasterxml.jackson.core.JsonPointer
+import com.typesafe.config.ConfigFactory
+import de.zalando.zally.rule.api.Check
+import de.zalando.zally.rule.api.Context
+import de.zalando.zally.rule.api.Rule
+import de.zalando.zally.rule.api.Severity
+import de.zalando.zally.rule.api.Violation
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class OpenApiRulesValidatorTest {
+    class RulesValidatorTestRuleSet : AbstractRuleSet()
+
+    @Rule(
+        ruleSet = RulesValidatorTestRuleSet::class,
+        id = "TestExtensionRule",
+        severity = Severity.MUST,
+        title = "TestExtensionRule"
+    )
+    class TestExtensionRule {
+        @Check(severity = Severity.MUST)
+        fun validate(context: Context): List<Violation> {
+            val testExtension = context
+                ?.api
+                ?.info
+                ?.extensions?.get("x-test-extension")
+                ?.let { it as? Map<*, *>? }
+
+            return testExtension
+                ?.values
+                ?.filterNotNull()
+                ?.map { value -> context.violation("Invalid value", value) }
+                ?: listOf()
+        }
+    }
+
+    @Test
+    fun checkCorrectLineNumbersForExtensionViolation() {
+        @Language("yaml")
+        val openApiContent = """
+            openapi: '3.0.0'
+            info:
+              x-test-extension:
+                nested: 42
+                paths: test-string
+                and:
+                  some:
+                    more: 12
+              title: Lorem Ipsum
+            paths: {}
+            """.trimIndent()
+
+        val validator = openApiRulesValidator(listOf(TestExtensionRule()), DefaultContextFactory())
+        val results = validator.validate(openApiContent, RulesPolicy(emptyList()))
+        assertThat(results.map { it.pointer }).containsExactly(
+            JsonPointer.compile("/info/x-test-extension/nested"),
+            JsonPointer.compile("/info/x-test-extension/paths"),
+            JsonPointer.compile("/info/x-test-extension/and")
+        )
+
+        assertThat(results.map { it.lines }).containsExactly(
+            IntRange(4, 4),
+            IntRange(5, 5),
+            IntRange(6, 9)
+        )
+    }
+
+    private fun openApiRulesValidator(rules: List<Any>, context: DefaultContextFactory): RulesValidator<Context> =
+        object : RulesValidator<Context>(RulesManager.fromInstances(ConfigFactory.empty(), rules)) {
+            override fun parse(content: String, authorization: String?): ContentParseResult<Context> =
+                context.parseOpenApiContext(content, authorization)
+
+            override fun ignore(root: Context, pointer: JsonPointer, ruleId: String): Boolean = false
+        }
+}

--- a/server/zally-core/src/test/kotlin/de/zalando/zally/core/SwaggerRulesValidatorTest.kt
+++ b/server/zally-core/src/test/kotlin/de/zalando/zally/core/SwaggerRulesValidatorTest.kt
@@ -14,7 +14,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 
 @Suppress("UndocumentedPublicClass", "StringLiteralDuplication")
-class RulesValidatorTest {
+class SwaggerRulesValidatorTest {
 
     private val swaggerContent =
         resourceToString("fixtures/api_spp.json")


### PR DESCRIPTION
* Based on https://github.com/zalando/zally/issues/1148.

Previously, `ReverseAstBuilder` was appending `/extensions` or `/vendorExtensions` to `JsonNode` paths, which was messing up line numbers when trying to pass JsonNode values as context violations.