### PR TITLE
feat: Working docker-compose healthchecks

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,12 @@ services:
     - server:server.local
     ports:
     - "8080:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
   server:
     build: ./server
     depends_on:
@@ -45,3 +51,8 @@ services:
     - POSTGRES_DB=zally
     ports:
     - "54321:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/server/zally-server/src/main/resources/application-dev.yml
+++ b/server/zally-server/src/main/resources/application-dev.yml
@@ -22,10 +22,6 @@ twintip:
 server:
   port: 8000 # using the same port as the web-ui expects (see `docker-compose.yaml`)
 
-management:
-  server:
-    port: 8000 # listening on the same port (`server` and `management.server`)
-
 zally:
   cli:
     releasesPage: https://github.com/zalando/zally/releases

--- a/server/zally-server/src/main/resources/application.yml
+++ b/server/zally-server/src/main/resources/application.yml
@@ -28,7 +28,7 @@ management:
       exposure:
         include: health, metrics
   server:
-    port: ${MANAGEMENT_PORT}
+    port: ${MANAGEMENT_PORT:7979}
 
 twintip:
   mapping: /api
@@ -45,4 +45,3 @@ zally:
 ---
 spring.profiles: local
 TOKEN_INFO_URI: https://auth.example.com/oauth2/tokeninfo
-MANAGEMENT_PORT: 7979


### PR DESCRIPTION
Listing docker compose containers now shows healthy state:
```
      Name                    Command                  State                    Ports              
---------------------------------------------------------------------------------------------------
zally_postgres_1   docker-entrypoint.sh postgres    Up (healthy)   0.0.0.0:54321->5432/tcp         
zally_server_1     /bin/sh -c java $(java-dyn ...   Up (healthy)   0.0.0.0:8000->8000/tcp, 8080/tcp
zally_web-ui_1     node server.js                   Up (healthy)   0.0.0.0:8080->3000/tcp          
```

Closes #1133