### PR TITLE
Empty version for "zally-server" version

### DIFF
--- a/server/zally-server/build.gradle.kts
+++ b/server/zally-server/build.gradle.kts
@@ -1,3 +1,6 @@
+// Version set to empty to make artifact name in line with the name defined in Dockerfile
+version = ""
+
 buildscript {
     extra.apply {
         // sets the jackson version that spring uses


### PR DESCRIPTION
Make `zally-server` version empty to fix current Docker image build process.

Related to #964 