### PR TITLE
Implement rules for enums

### DIFF
--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/util/OpenApiUtil.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/util/OpenApiUtil.kt
@@ -130,7 +130,7 @@ private fun Schema<Any>.customHash(): Int = Objects.hash(
     example, externalDocs, deprecated, xml, extensions, discriminator
 )
 
-fun Schema<Any>.isEnum(): Boolean = this.enum != null && this.enum.isNotEmpty()
+fun Schema<Any>.isEnum(): Boolean = this.enum?.isNotEmpty() ?: false
 
 fun Schema<Any>.isExtensibleEnum(): Boolean =
     this.extensions?.containsKey("x-extensible-enum") ?: false

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/util/OpenApiUtil.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/util/OpenApiUtil.kt
@@ -129,3 +129,13 @@ private fun Schema<Any>.customHash(): Int = Objects.hash(
     required, type, not, properties, additionalProperties, description, format, `$ref`, nullable, readOnly, writeOnly,
     example, externalDocs, deprecated, xml, extensions, discriminator
 )
+
+fun Schema<Any>.isEnum(): Boolean = this.enum != null && this.enum.isNotEmpty()
+
+fun Schema<Any>.isExtensibleEnum(): Boolean =
+    this.extensions?.containsKey("x-extensible-enum") ?: false
+
+fun Schema<Any>.extensibleEnum(): List<String> =
+    if (this.isExtensibleEnum()) {
+        (this.extensions["x-extensible-enum"] as List<*>).map { it.toString() }
+    } else emptyList()

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/EnumValueTypeRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/EnumValueTypeRule.kt
@@ -1,0 +1,36 @@
+package org.zalando.zally.ruleset.zalando
+
+import org.zalando.zally.core.util.getAllProperties
+import org.zalando.zally.core.util.getAllSchemas
+import org.zalando.zally.core.util.isExtensibleEnum
+import org.zalando.zally.rule.api.Check
+import org.zalando.zally.rule.api.Context
+import org.zalando.zally.rule.api.Rule
+import org.zalando.zally.rule.api.Severity
+import org.zalando.zally.rule.api.Violation
+
+@Rule(
+    ruleSet = ZalandoRuleSet::class,
+    id = "125",
+    severity = Severity.SHOULD,
+    title = "Represent enumerations as strings"
+)
+class EnumValueTypeRule {
+
+    private val description = "Enumeration value should have \"type = string\""
+
+    @Check(severity = Severity.SHOULD)
+    fun validate(context: Context): List<Violation> =
+        context.api.getAllSchemas()
+            .filter { it.isExtensibleEnum() }
+            .filter { it.type != "string" }
+            .map {
+                context.violation("$description: ${it.name}", it)
+            } +
+            context.api.getAllProperties()
+                .filter { it.value.isExtensibleEnum() }
+                .filter { it.value.type != "string" }
+                .map {
+                    context.violation("$description: ${it.key}", it.value)
+                }
+}

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UpperCaseEnums.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UpperCaseEnums.kt
@@ -22,7 +22,7 @@ class UpperCaseEnums {
 
     private val pattern = "[A-Z_0-9]*".toRegex()
 
-    private val description = "Enum value should use UPPER_SNAKE_CASE format"
+    private val description = "Enum value(s) should use UPPER_SNAKE_CASE format"
 
     @Check(severity = Severity.SHOULD)
     fun validate(context: Context): List<Violation> =
@@ -34,7 +34,7 @@ class UpperCaseEnums {
                     validateExtensibleEnum(it)
                 } else {
                     validateEnum(it)
-                }.map { enumValue -> context.violation("$description: $enumValue", it) }
+                }.map { enumValue -> context.violation("$description. Incorrect value: $enumValue", it) }
             } +
             context.api.getAllProperties()
                 .filter { it.value.type == "string" }
@@ -45,7 +45,7 @@ class UpperCaseEnums {
                     } else {
                         validateEnum(property)
                     }.map {
-                        context.violation("$description: $propName", it)
+                        context.violation("$propName: $description. Incorrect value: $it", it)
                     }
                 }
 

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UpperCaseEnums.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UpperCaseEnums.kt
@@ -1,0 +1,57 @@
+package org.zalando.zally.ruleset.zalando
+
+import io.swagger.v3.oas.models.media.Schema
+import org.zalando.zally.core.util.extensibleEnum
+import org.zalando.zally.core.util.getAllProperties
+import org.zalando.zally.core.util.getAllSchemas
+import org.zalando.zally.core.util.isEnum
+import org.zalando.zally.core.util.isExtensibleEnum
+import org.zalando.zally.rule.api.Check
+import org.zalando.zally.rule.api.Context
+import org.zalando.zally.rule.api.Rule
+import org.zalando.zally.rule.api.Severity
+import org.zalando.zally.rule.api.Violation
+
+@Rule(
+    ruleSet = ZalandoRuleSet::class,
+    id = "240",
+    severity = Severity.SHOULD,
+    title = "Declare enum values using UPPER_SNAKE_CASE format"
+)
+class UpperCaseEnums {
+
+    private val pattern = "[A-Z_0-9]*".toRegex()
+
+    private val description = "Enum value should use UPPER_SNAKE_CASE format"
+
+    @Check(severity = Severity.SHOULD)
+    fun validate(context: Context): List<Violation> =
+        context.api.getAllSchemas()
+            .filter { it.type == "string" }
+            .filter { it.isExtensibleEnum() || it.isEnum() }
+            .flatMap {
+                if (it.isExtensibleEnum()) {
+                    validateExtensibleEnum(it)
+                } else {
+                    validateEnum(it)
+                }.map { enumValue -> context.violation("$description: $enumValue", it) }
+            } +
+            context.api.getAllProperties()
+                .filter { it.value.type == "string" }
+                .filter { it.value.isExtensibleEnum() || it.value.isEnum() }
+                .flatMap { (propName, property) ->
+                    if (property.isExtensibleEnum()) {
+                        validateExtensibleEnum(property)
+                    } else {
+                        validateEnum(property)
+                    }.map {
+                        context.violation("$description: $propName", it)
+                    }
+                }
+
+    private fun validateExtensibleEnum(property: Schema<Any>): List<String> =
+        property.extensibleEnum().filter { !pattern.matches(it) }
+
+    private fun validateEnum(property: Schema<Any>): List<String> =
+        property.enum.map { it.toString() }.filter { !pattern.matches(it) }
+}

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/EnumValueTypeTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/EnumValueTypeTest.kt
@@ -1,0 +1,73 @@
+package org.zalando.zally.ruleset.zalando
+
+import org.assertj.core.api.Assertions
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+import org.zalando.zally.core.DefaultContextFactory
+
+class EnumValueTypeTest {
+
+    private val rule = EnumValueTypeRule()
+
+    @Test
+    fun `fail validation if "x-extensible-enum" has a "string" type`() {
+        @Language("YAML")
+        val spec = """
+            openapi: 3.0.1
+            paths:
+              /article:
+                get:
+                  responses: 
+                    200:
+                      description: The identifiers associated with the source id.
+                      content: 
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              prop-1:
+                                type: integer
+                                x-extensible-enum:
+                                  - 1
+                                  - 2
+                                  - 3
+                    
+        """.trimIndent()
+
+        val context = DefaultContextFactory().getOpenApiContext(spec)
+
+        val violations = rule.validate(context)
+        Assertions.assertThat(violations).hasSize(1)
+    }
+
+    @Test
+    fun `pass validation if "x-extensible-enum" has a "string" type`() {
+        @Language("YAML")
+        val spec = """
+            openapi: 3.0.1
+            paths:
+              /article:
+                get:
+                  responses: 
+                    200:
+                      description: The identifiers associated with the source id.
+                      content: 
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              prop-1:
+                                type: string
+                                x-extensible-enum:
+                                  - one
+                                  - two
+                                  - three
+                    
+        """.trimIndent()
+
+        val context = DefaultContextFactory().getOpenApiContext(spec)
+
+        val violations = rule.validate(context)
+        Assertions.assertThat(violations).isEmpty()
+    }
+}

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UpperCaseEnumsTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UpperCaseEnumsTest.kt
@@ -107,7 +107,21 @@ class UpperCaseEnumsTest {
                           - GERMANY
                           - SWEDEN
                           - PUT_YOUR_COUNTRY_HERE
-                          - COUNTRY_1 
+                          - COUNTRY_1
+                  responses: 
+                    200:
+                      description: The identifiers associated with the source id.
+                      content: 
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              prop-1:
+                                type: string
+                                x-extensible-enum:
+                                  - GERMANY
+                                  - SWEDEN
+                                  - SPAIN
         """.trimIndent()
 
         val context = DefaultContextFactory().getOpenApiContext(spec)

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UpperCaseEnumsTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UpperCaseEnumsTest.kt
@@ -1,0 +1,118 @@
+package org.zalando.zally.ruleset.zalando
+
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+import org.zalando.zally.core.DefaultContextFactory
+
+class UpperCaseEnumsTest {
+
+    private val rule = UpperCaseEnums()
+
+    @Test
+    fun `should return violation if x-extensible-enum format in parameter is incorrect`() {
+        @Language("YAML")
+        val spec = """
+            openapi: 3.0.1
+            paths:
+              /article:
+                get:
+                  parameters:
+                    - name: country
+                      in: query
+                      schema:
+                        type: string
+                        x-extensible-enum:
+                          - GERMANY
+                          - sweden
+                          - spain
+        """.trimIndent()
+
+        val context = DefaultContextFactory().getOpenApiContext(spec)
+
+        val violations = rule.validate(context)
+        assertThat(violations).hasSize(2)
+    }
+
+    @Test
+    fun `should return violation if x-extensible-enum format in schema property is invalid`() {
+        @Language("YAML")
+        val spec = """
+            openapi: 3.0.1
+            paths:
+              /article:
+                get:
+                  responses: 
+                    200:
+                      description: The identifiers associated with the source id.
+                      content: 
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              prop-1:
+                                type: string
+                                x-extensible-enum:
+                                  - GERMANY
+                                  - sweden
+                                  - spain
+                    
+        """.trimIndent()
+
+        val context = DefaultContextFactory().getOpenApiContext(spec)
+
+        val violations = rule.validate(context)
+        assertThat(violations).hasSize(2)
+    }
+
+    @Test
+    fun `rule should return violation if enum format is incorrect`() {
+        @Language("YAML")
+        val spec = """
+            openapi: 3.0.1
+            paths:
+              /article:
+                get:
+                  parameters:
+                    - name: country
+                      in: query
+                      schema:
+                        type: string
+                        enum:
+                          - GERMANY
+                          - sweden
+                          - spain
+        """.trimIndent()
+
+        val context = DefaultContextFactory().getOpenApiContext(spec)
+
+        val violations = rule.validate(context)
+        assertThat(violations).hasSize(2)
+    }
+
+    @Test
+    fun `rule should return no violations`() {
+        @Language("YAML")
+        val spec = """
+            openapi: 3.0.1
+            paths:
+              /article:
+                get:
+                  parameters:
+                    - name: country
+                      in: query
+                      schema:
+                        type: string
+                        enum:
+                          - GERMANY
+                          - SWEDEN
+                          - PUT_YOUR_COUNTRY_HERE
+                          - COUNTRY_1 
+        """.trimIndent()
+
+        val context = DefaultContextFactory().getOpenApiContext(spec)
+
+        val violations = rule.validate(context)
+        assertThat(violations).isEmpty()
+    }
+}


### PR DESCRIPTION
* Implement [Rule 240](https://opensource.zalando.com/restful-api-guidelines/#240)
* Implement [Rule 125]() only for `x-extensible-enum`. OpenAPI schema forbid to have `enum` properties of types other than `string`.

Fixes #1183 