### PR TITLE
Add Fashion Platform GW headers

### DIFF
--- a/server/zally-ruleset-zalando/src/main/resources/reference.conf
+++ b/server/zally-ruleset-zalando/src/main/resources/reference.conf
@@ -3,9 +3,8 @@
 HttpHeadersRule {
   whitelist: [ETag, TSV, TE, Content-MD5, DNT, X-ATT-DeviceId, X-UIDH, X-Request-ID, X-Correlation-ID,
     WWW-Authenticate, X-XSS-Protection, X-Flow-ID, X-UID, X-Tenant-ID, X-Device-OS, X-Trace-ID,
-    X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, 
-    X-Zalando-Client-ID, X-Zalando-Request-Host, X-Zalando-Request-URI,
-    X-Consumer, X-Consumer-Signature, X-Consumer-Key-ID]
+    X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-Consumer, X-Consumer-Signature, X-Consumer-Key-ID,
+    X-Zalando-Request-URI]
 }
 
 LimitNumberOfResourcesRule {
@@ -203,7 +202,10 @@ ProprietaryHeadersRule {
     "X-RateLimit-Reset",
     "X-Consumer",
     "X-Consumer-Signature",
-    "X-Consumer-Key-ID"
+    "X-Consumer-Key-ID",
+    "X-Zalando-Client-ID",
+    "X-Zalando-Request-Host",
+    "X-Zalando-Request-URI"
   ]
 }
 


### PR DESCRIPTION
Fashion Platform GW headers and exclude `X-Zalando-Request-URI` from the [Rule 166](https://opensource.zalando.com/restful-api-guidelines/#166), 

Fixes #1216 