### PR TITLE
Add Rule 127 - Use JSON as payload data interchange format

### DIFF
--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/MediaType.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/MediaType.kt
@@ -1,0 +1,5 @@
+package org.zalando.zally.core
+
+enum class MediaType(val type: String) {
+    APPLICATION_JSON("application/json")
+}

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/util/OpenApiUtil.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/util/OpenApiUtil.kt
@@ -1,6 +1,8 @@
 package org.zalando.zally.core.util
 
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.oas.models.responses.ApiResponse
@@ -139,3 +141,6 @@ fun Schema<Any>.extensibleEnum(): List<String> =
     if (this.isExtensibleEnum()) {
         (this.extensions["x-extensible-enum"] as List<*>).map { it.toString() }
     } else emptyList()
+
+fun PathItem.allOperations(): List<Operation> =
+    listOf(this.head, this.get, this.post, this.delete, this.put, this.trace, this.options, this.patch)

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseJsonPayload.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseJsonPayload.kt
@@ -1,0 +1,43 @@
+package org.zalando.zally.ruleset.zalando
+
+import io.swagger.v3.oas.models.media.Content
+import org.zalando.zally.core.MediaType
+import org.zalando.zally.core.util.allOperations
+import org.zalando.zally.rule.api.Check
+import org.zalando.zally.rule.api.Context
+import org.zalando.zally.rule.api.Rule
+import org.zalando.zally.rule.api.Severity
+import org.zalando.zally.rule.api.Violation
+
+@Rule(
+    ruleSet = ZalandoRuleSet::class,
+    id = "167",
+    severity = Severity.MUST,
+    title = "Use JSON payload as interchange format"
+)
+class UseJsonPayload {
+
+    val description = "Payload should be a JSON. Actual:"
+
+    @Check(severity = Severity.MUST)
+    fun validatePayload(context: Context): List<Violation> {
+
+        val validateContent: (Content) -> List<Violation> = { content ->
+            content.filter { (key, _) -> key != MediaType.APPLICATION_JSON.type }
+                .map { context.violation("$description ${it.key}", it.value) }
+        }
+
+        val allOperations = context.api.paths.flatMap { (_, path) -> path.allOperations().filterNotNull() }
+
+        val requestViolations =
+            allOperations.filter { it.requestBody?.content != null }.flatMap { validateContent(it.requestBody.content) }
+
+        val responseViolations = allOperations
+            .filter { it.responses.isNotEmpty() }
+            .flatMap { it.responses.entries }
+            .mapNotNull { it.value.content }
+            .flatMap(validateContent)
+
+        return requestViolations + responseViolations
+    }
+}

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseJsonPayloadRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseJsonPayloadRuleTest.kt
@@ -1,0 +1,121 @@
+package org.zalando.zally.ruleset.zalando
+
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.test.ZallyAssertions
+
+class UseJsonPayloadRuleTest {
+
+    private val rule = UseJsonPayload()
+
+    @Test
+    fun `return violation if a request contains non JSON format`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+            """
+            openapi: '3.0.0'
+            paths:
+              /create:
+                post:
+                  summary: Create a pet
+                  requestBody:
+                      content:
+                        application/custom-format:
+                          schema:
+                            type: object
+                            properties:
+                              req-prop:
+                                type: string          
+                  responses:
+                    '201':
+                      description: Null response
+                    default:
+                      description: unexpected error
+              
+            
+        """.trimIndent()
+        )
+
+        val violations = rule.validatePayload(context)
+        ZallyAssertions.assertThat(violations).hasSize(1)
+    }
+
+    @Test
+    fun `return violation if a response contains non JSON format`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+            """
+            openapi: '3.0.0'
+            paths:
+              /list:
+                get:
+                  summary: Get data
+                  responses:
+                    '201':
+                      description: Null response
+                    default:
+                      description: unexpected error
+                      content:
+                        application/pdf:
+                          schema:
+                            type: object
+                            properties:
+                              prop1:
+                                type: string
+              
+            
+        """.trimIndent()
+        )
+
+        val violations = rule.validatePayload(context)
+        ZallyAssertions.assertThat(violations).hasSize(1)
+    }
+
+    @Test
+    fun `return no violations`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+            """
+            openapi: '3.0.0'
+            paths:
+              /create:
+                post:
+                  summary: Create a pet
+                  requestBody:
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              req-prop:
+                                type: string          
+                  responses:
+                    '201':
+                      description: Null response
+                    default:
+                      description: unexpected error            
+              /list:
+                get:
+                  summary: Get data
+                  responses:
+                    '201':
+                      description: Null response
+                    default:
+                      description: unexpected error
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              prop1:
+                                type: string
+              
+            
+        """.trimIndent()
+        )
+
+        val violations = rule.validatePayload(context)
+        ZallyAssertions.assertThat(violations).isEmpty()
+    }
+}


### PR DESCRIPTION
Implement [Rule 167](https://opensource.zalando.com/restful-api-guidelines/#167)

- [ ] Add support for the acceptance list of media types

Fixes #1217 