### PR TITLE
Fix `cd` path of CLI build instructions

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -18,7 +18,7 @@ requesting violations check at a given Zally server.
 1. Run tests:
 
     ```bash
-    cd zally
+    cd zally/cli/zally
     GO111MODULE=on ./test.sh
     ```
 


### PR DESCRIPTION
Currently the path mentioned for the `cd` command is incorrect.