### PR TITLE
Add request and response parameters structure validation.

### DIFF
--- a/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/PathParameterRule.kt
+++ b/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/PathParameterRule.kt
@@ -39,29 +39,29 @@ class PathParameterRule {
 
     @Check(severity = Severity.MUST)
     fun checkSchemaOrContentProperty(context: Context): List<Violation> {
-        if (!context.isOpenAPI3()) {
-            emptyList<Violation>()
+        if (context.isOpenAPI3()) {
+            return context.api
+                .getAllParameters()
+                .filterValues { it.schema == null && it.content == null }
+                .map { (_, parameter) ->
+                    context.violation(requiredSchemaOrContentErrorMessage(parameter.name), parameter)
+                }
         }
-        return context.api
-            .getAllParameters()
-            .filterValues { it.schema == null && it.content == null }
-            .map { (_, parameter) ->
-                context.violation(requiredSchemaOrContentErrorMessage(parameter.name), parameter)
-            }
+        return emptyList()
     }
 
     @Check(severity = Severity.MUST)
     fun validateParameterContentMapStructure(context: Context): List<Violation> {
-        if (!context.isOpenAPI3()) {
-            emptyList<Violation>()
+        if (context.isOpenAPI3()) {
+            return context.api.getAllParameters()
+                .filterValues {
+                    val contentMap = it.content.orEmpty()
+                    contentMap.isEmpty() || contentMap.size > 1
+                }
+                .map { (_, parameter) ->
+                    context.violation(contentMapStructureErrorMessage(parameter.name), parameter)
+                }
         }
-        return context.api.getAllParameters()
-            .filterValues {
-                val contentMap = it.content.orEmpty()
-                contentMap.isEmpty() || contentMap.size > 1
-            }
-            .map { (_, parameter) ->
-                context.violation(contentMapStructureErrorMessage(parameter.name), parameter)
-            }
+        return emptyList()
     }
 }

--- a/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/PathParameterRule.kt
+++ b/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/PathParameterRule.kt
@@ -12,21 +12,48 @@ import org.zalando.zally.rule.api.Violation
     ruleSet = ZallyRuleSet::class,
     id = "Z001",
     severity = Severity.MUST,
-    title = "Path parameters must have 'required' attribute"
+    title = "Path parameters validation"
 )
 class PathParameterRule {
 
     companion object {
-        const val ERROR_MESSAGE = "Parameter with location \"path\" must have an attribute \"required=true\" set"
+        const val REQUIRED_ATTRIBUTE_ERROR_MESSAGE =
+            "Parameter with location \"path\" must have an attribute \"required=true\" set"
+
+        fun requiredSchemaOrContentErrorMessage(parameterName: String) =
+            "Parameter $parameterName should have either \"schema\" or \"content\" defined"
+
+        fun contentMapStructureErrorMessage(parameterName: String) =
+            "Parameter $parameterName: \"content\" property should have exactly one entry"
     }
 
     @Check(severity = Severity.MUST)
-    fun validate(context: Context): List<Violation> =
+    fun checkRequiredPathAttribute(context: Context): List<Violation> =
         context.api.getAllParameters().map { entry -> entry.value }
             .filter { parameter ->
                 parameter.isInPath() && !parameter.required
             }
             .map {
-                context.violation(ERROR_MESSAGE, it)
+                context.violation(REQUIRED_ATTRIBUTE_ERROR_MESSAGE, it)
+            }
+
+    @Check(severity = Severity.MUST)
+    fun checkSchemaOrContentProperty(context: Context): List<Violation> =
+        context.api
+            .getAllParameters()
+            .filterValues { it.schema == null && it.content == null }
+            .map { (_, parameter) ->
+                context.violation(requiredSchemaOrContentErrorMessage(parameter.name), parameter)
+            }
+
+    @Check(severity = Severity.MUST)
+    fun validateParameterContentMapStructure(context: Context) =
+        context.api.getAllParameters()
+            .filterValues {
+                val contentMap = it.content.orEmpty()
+                contentMap.isEmpty() || contentMap.size > 1
+            }
+            .map { (_, parameter) ->
+                context.violation(contentMapStructureErrorMessage(parameter.name), parameter)
             }
 }

--- a/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/PathParameterRule.kt
+++ b/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/PathParameterRule.kt
@@ -38,17 +38,24 @@ class PathParameterRule {
             }
 
     @Check(severity = Severity.MUST)
-    fun checkSchemaOrContentProperty(context: Context): List<Violation> =
-        context.api
+    fun checkSchemaOrContentProperty(context: Context): List<Violation> {
+        if (!context.isOpenAPI3()) {
+            emptyList<Violation>()
+        }
+        return context.api
             .getAllParameters()
             .filterValues { it.schema == null && it.content == null }
             .map { (_, parameter) ->
                 context.violation(requiredSchemaOrContentErrorMessage(parameter.name), parameter)
             }
+    }
 
     @Check(severity = Severity.MUST)
-    fun validateParameterContentMapStructure(context: Context) =
-        context.api.getAllParameters()
+    fun validateParameterContentMapStructure(context: Context): List<Violation> {
+        if (!context.isOpenAPI3()) {
+            emptyList<Violation>()
+        }
+        return context.api.getAllParameters()
             .filterValues {
                 val contentMap = it.content.orEmpty()
                 contentMap.isEmpty() || contentMap.size > 1
@@ -56,4 +63,5 @@ class PathParameterRule {
             .map { (_, parameter) ->
                 context.violation(contentMapStructureErrorMessage(parameter.name), parameter)
             }
+    }
 }

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/PathParameterRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/PathParameterRuleTest.kt
@@ -10,7 +10,7 @@ class PathParameterRuleTest {
     private val rule = PathParameterRule()
 
     @Test
-    internal fun `return violation if a path parameter is not marked as "required"`() {
+    internal fun `return violation if a path parameter is not marked as 'required'`() {
         @Language("YAML")
         val context = DefaultContextFactory().getOpenApiContext(
             """
@@ -38,15 +38,15 @@ class PathParameterRuleTest {
             """.trimIndent()
         )
 
-        val violations = rule.validate(context)
+        val violations = rule.checkRequiredPathAttribute(context)
 
         assertThat(violations)
-            .descriptionsAllEqualTo(PathParameterRule.ERROR_MESSAGE)
+            .descriptionsAllEqualTo(PathParameterRule.REQUIRED_ATTRIBUTE_ERROR_MESSAGE)
             .pointersEqualTo("/paths/~1items~1{item-id}/get/parameters/0")
     }
 
     @Test
-    fun `return no violations if a path parameter marked as "required"`() {
+    fun `return no violations if a path parameter marked as 'required'`() {
         @Language("YAML")
         val context = DefaultContextFactory().getOpenApiContext(
             """
@@ -74,12 +74,12 @@ class PathParameterRuleTest {
                            type: string
             """.trimIndent()
         )
-        val violations = rule.validate(context)
+        val violations = rule.checkRequiredPathAttribute(context)
         assertThat(violations).isEmpty()
     }
 
     @Test
-    internal fun `return violation if a path parameter in components is not marked as "required"`() {
+    internal fun `return violation if a path parameter in components is not marked as 'required'`() {
         @Language("YAML")
         val context = DefaultContextFactory().getOpenApiContext(
             """
@@ -111,10 +111,165 @@ class PathParameterRuleTest {
             """.trimIndent()
         )
 
-        val violations = rule.validate(context)
+        val violations = rule.checkRequiredPathAttribute(context)
 
         assertThat(violations)
-            .descriptionsAllEqualTo(PathParameterRule.ERROR_MESSAGE)
+            .descriptionsAllEqualTo(PathParameterRule.REQUIRED_ATTRIBUTE_ERROR_MESSAGE)
             .pointersEqualTo("/components/parameters/QueryParameter")
+    }
+
+    @Test
+    fun `return violation if parameter has no 'schema' and 'content' defined`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+            """
+            openapi: '3.0.0'
+            info:
+              title: Schema and content Parameter properties validation
+              contact: 
+                info: "Team One"               
+            paths:
+              /endpoint:
+                post:
+                  summary: |
+                    Some summary.
+                  security:
+                    - oauth2: ["uid"]
+                  parameters:
+                    - name: X-HEADER-ID
+                      description: |
+                        Header description
+                      in: header
+                      required: false
+                    - $\ref: "#/components/parameters/QueryParameter"
+            components: 
+              parameters:
+                QueryParameter:
+                  name: item-id
+                  in: path                  
+                  description: The id of the pet to retrieve
+                      """.trimIndent()
+        )
+
+        val violations = rule.checkSchemaOrContentProperty(context)
+
+        assertThat(violations).hasSize(2)
+        assertThat(violations).containsDescriptionsInAnyOrder(
+            PathParameterRule.requiredSchemaOrContentErrorMessage("X-HEADER-ID"),
+            PathParameterRule.requiredSchemaOrContentErrorMessage("item-id")
+        )
+    }
+
+    @Test
+    fun `return no violations if either 'schema' or 'content' are present`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+            """
+            openapi: '3.0.0'
+            info:
+              title: Schema and content Parameter properties validation
+              contact: 
+                info: "Team One"               
+            paths:
+              /endpoint:
+                post:
+                  summary: |
+                    Some summary.
+                  security:
+                    - oauth2: ["uid"]
+                  parameters:
+                    - name: X-HEADER-ID
+                      description: Header description
+                      in: header
+                      required: false
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties: 
+                              x:
+                                type: string
+                    - $\ref: "#/components/parameters/QueryParameter"
+            components: 
+              parameters:
+                QueryParameter:
+                  name: item-id
+                  in: path                  
+                  description: The id of the pet to retrieve
+                  schema:
+                    type: string
+                      """.trimIndent()
+        )
+
+        val violations = rule.checkSchemaOrContentProperty(context)
+
+        assertThat(violations).isEmpty()
+    }
+
+    @Test
+    fun `return violation if 'content' field contains more than one key`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+            """
+            openapi: '3.0.0'
+            info:
+              title: Schema and content Parameter properties validation
+              contact: 
+                info: "Team One"               
+            paths:
+              /endpoint:
+                post:
+                  summary: |
+                    Some summary.
+                  security:
+                    - oauth2: ["uid"]
+                  parameters:
+                    - name: X-VALID-HEADER
+                      description: Header description
+                      in: header
+                      required: false
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties: 
+                              x:
+                                type: string
+                    - name: X-HEADER-ID
+                      description: Header description
+                      in: header
+                      required: false
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties: 
+                              x:
+                                type: string
+                        application/xml:
+                          schema:
+                            type: object
+                            properties: 
+                              x:
+                                type: string
+                    - $\ref: "#/components/parameters/QueryParameter"
+            components: 
+              parameters:
+                QueryParameter:
+                  name: item-id
+                  in: path                  
+                  description: The id of the pet to retrieve
+                  content: 
+                  
+                      """.trimIndent()
+        )
+
+        val violations = rule.validateParameterContentMapStructure(context)
+
+        assertThat(violations).hasSize(2)
+        assertThat(violations).containsDescriptionsInAnyOrder(
+            PathParameterRule.contentMapStructureErrorMessage("X-HEADER-ID"),
+            PathParameterRule.contentMapStructureErrorMessage("item-id")
+        )
     }
 }

--- a/server/zally-test/src/main/kotlin/org/zalando/zally/test/ViolationsAssert.kt
+++ b/server/zally-test/src/main/kotlin/org/zalando/zally/test/ViolationsAssert.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.test
 
-import org.zalando.zally.rule.api.Violation
 import org.assertj.core.api.AbstractListAssert
 import org.assertj.core.api.ListAssert
 import org.assertj.core.api.ObjectAssert
+import org.zalando.zally.rule.api.Violation
 
 @Suppress("UndocumentedPublicClass", "SpreadOperator")
 class ViolationsAssert(violations: List<Violation>?) :
@@ -30,6 +30,14 @@ class ViolationsAssert(violations: List<Violation>?) :
 
     fun descriptionsEqualTo(vararg descriptions: String): ViolationsAssert {
         descriptions().containsExactly(*descriptions)
+        return this
+    }
+
+    /**
+     * Verifies that violations list contains violations with provides descriptions in any order
+     */
+    fun containsDescriptionsInAnyOrder(vararg descriptions: String): ViolationsAssert {
+        descriptions().containsExactlyInAnyOrder(*descriptions)
         return this
     }
 


### PR DESCRIPTION
Add the following [Parameter Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterObject) validations.

1. _A parameter MUST contain either a schema property, or a content property, but not both._
2. _The map_ (means `content` map) _MUST only contain one entry._

Fixes #1169 