### PR TITLE
Fix Docker base images

### DIFF
--- a/github-integration/Dockerfile
+++ b/github-integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:1.8.0-131-8
+FROM registry.opensource.zalan.do/library/openjdk-11-jdk-slim:latest
 
 MAINTAINER "http://zalando.github.io/"
 LABEL MAINTAINER "http://zalando.github.io/"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,13 +1,13 @@
 #
 # Build the java application in a separate container.
 #
-FROM registry.opensource.zalan.do/stups/openjdk:latest as builder
+FROM registry.opensource.zalan.do/library/openjdk-11-jdk-slim:latest as builder
 COPY . /src
 WORKDIR /src
 RUN ./gradlew build --info
 
 
-FROM registry.opensource.zalan.do/stups/openjdk:latest
+FROM registry.opensource.zalan.do/library/openjdk-11-jdk-slim:latest
 
 MAINTAINER "http://zalando.github.io/"
 


### PR DESCRIPTION
Update docker base images for Zally server and github-integration.

Fixes deployment problem in  #1254
Related to #1254 