### PR TITLE
Register Jackson datetime module for custom parser

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -146,13 +146,14 @@ subprojects {
     }
 
     dependencies {
+        implementation(platform("com.fasterxml.jackson:jackson-bom:2.12.2"))
         implementation("org.jetbrains.kotlin:kotlin-stdlib")
 
         // We define this here so all subprojects use the same version of jackson
-        implementation("com.fasterxml.jackson.module:jackson-module-parameter-names:2.12.2")
-        implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.2")
-        implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.2")
-        implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.2")
+        implementation("com.fasterxml.jackson.module:jackson-module-parameter-names")
+        implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+        implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
+        implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
         implementation("org.yaml:snakeyaml:1.24")
 
         testImplementation("com.jayway.jsonpath:json-path-assert:2.4.0")

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseProblemJsonRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseProblemJsonRule.kt
@@ -3,7 +3,9 @@ package org.zalando.zally.ruleset.zalando
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.google.common.io.Resources
+import io.swagger.v3.oas.models.responses.ApiResponse
 import org.zalando.zally.core.EMPTY_JSON_POINTER
 import org.zalando.zally.core.JsonSchemaValidator
 import org.zalando.zally.core.ObjectTreeReader
@@ -13,7 +15,6 @@ import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import io.swagger.v3.oas.models.responses.ApiResponse
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,
@@ -26,7 +27,11 @@ class UseProblemJsonRule {
     private val description = "Operations should return problem JSON when any problem occurs during processing " +
         "whether caused by client or server."
 
-    private val objectMapper by lazy { ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL) }
+    private val objectMapper by lazy {
+        ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .registerModule(JavaTimeModule())
+    }
 
     private val problemSchemaValidator by lazy {
         val schemaUrl = Resources.getResource("schemas/problem-meta-schema.json")

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseProblemJsonRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseProblemJsonRuleTest.kt
@@ -59,10 +59,6 @@ class UseProblemJsonRuleTest {
                           schema:
                             type: object
                             properties:
-                              created:
-                                type: string
-                                format: date-time
-                                example: '2020-05-14T14:22:01Z'
                               status:
                                 type: string
         """.trimIndent()

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseProblemJsonRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseProblemJsonRuleTest.kt
@@ -59,6 +59,10 @@ class UseProblemJsonRuleTest {
                           schema:
                             type: object
                             properties:
+                              created:
+                                type: string
+                                format: date-time
+                                example: '2020-05-14T14:22:01Z'
                               status:
                                 type: string
         """.trimIndent()
@@ -262,5 +266,38 @@ class UseProblemJsonRuleTest {
                 "/components/schemas/Problem/properties/instance",
                 "/components/schemas/Problem/properties/instance/type"
             )
+    }
+
+    @Test
+    fun `should return no violation if date and time properties are used in the Problem object schema`() {
+        @Language("YAML")
+        val content = """
+            openapi: 3.0.1
+            info:
+              version: 1.0.0
+              title: Pets API
+            paths:
+              /bad:
+                get:
+                  responses:
+                    default:
+                      description: Lorem Ipsum
+                      content:
+                        application/problem+json:
+                          schema:
+                            type: object
+                            allOf: 
+                            - "$\ref": https://zalando.github.io/problem/schema.yaml#/Problem
+                            - type: object
+                              properties:
+                                created:
+                                  type: string
+                                  format: date-time
+                                  example: "2020-05-14T14:22:01Z" 
+        """.trimIndent()
+
+        val context = DefaultContextFactory().getOpenApiContext(content)
+        val violations = rule.validate(context)
+        ZallyAssertions.assertThat(violations).isEmpty()
     }
 }


### PR DESCRIPTION
* Since 2.12 the Java8 datetime module is not registered automatically.
* Switch Jackson dependencies to use Jackson BOM

Fixes #1285 