### PR TITLE
Remove `jcenter` repository dependency.

### DIFF
--- a/github-integration/build.gradle.kts
+++ b/github-integration/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
     repositories {
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
         maven("https://repo.spring.io/libs-release")
@@ -32,7 +31,6 @@ allprojects {
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
     repositories {
-        jcenter()
         mavenCentral()
     }
 

--- a/github-integration/build.gradle.kts
+++ b/github-integration/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     val hibernateVersion = "5.2.18.Final"
     val jacksonVersion = "2.9.8"
 
-    implementation("org.kohsuke:github-api:1.86")
+    implementation("org.kohsuke:github-api:1.131")
     implementation("io.swagger:swagger-parser:1.0.28")
     implementation("com.github.java-json-tools:json-schema-validator:2.2.8")
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/github-integration/build.gradle.kts
+++ b/github-integration/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         gradlePluginPortal()
         maven("https://repo.spring.io/libs-release")
@@ -31,6 +32,7 @@ allprojects {
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
     repositories {
+        jcenter()
         mavenCentral()
     }
 
@@ -44,7 +46,7 @@ dependencies {
     val hibernateVersion = "5.2.18.Final"
     val jacksonVersion = "2.9.8"
 
-    implementation("org.kohsuke:github-api:1.131")
+    implementation("org.kohsuke:github-api:1.86")
     implementation("io.swagger:swagger-parser:1.0.28")
     implementation("com.github.java-json-tools:json-schema-validator:2.2.8")
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -24,7 +24,6 @@ plugins {
 
 allprojects {
     repositories {
-        jcenter()
         mavenCentral()
         maven("https://jitpack.io")
     }


### PR DESCRIPTION
Remove jcenter repositories. See [Into the Sunset on May 1st: Bintray, GoCenter, and ChartCenter](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).

`github-integration` update has been moved to #1296 . The update triggers a lot of dependency changes and code rewriting in the module.