### PR TITLE
fix: remove duplicate hostname violations on invalid audience (#1386)

### DIFF
--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/FunctionalNamingForHostnamesRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/FunctionalNamingForHostnamesRule.kt
@@ -62,11 +62,12 @@ class FunctionalNamingForHostnamesRule(rulesConfig: Config) {
         val apiAudience = try {
             context.api.info?.apiAudience()
         } catch (e: UnsupportedAudienceException) {
-            return context.violations(e.message!!, context.api.info)
+            // case is covered by "APIAudienceRule"
+            return emptyList()
         }
         return when {
-            apiAudience !in audiencesToCheck -> emptyList()
-            apiAudience == null -> context.violations("API info section is not defined", context.api)
+            // cases are covered by "APIAudienceRule"
+            apiAudience == null || apiAudience !in audiencesToCheck -> emptyList()
             context.swagger != null -> checkHostnamesInSwaggerHost(context, apiAudience)
             else -> checkHostnamesInOpenAPIServers(context, apiAudience)
         }

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/FunctionalNamingForHostnamesRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/FunctionalNamingForHostnamesRuleTest.kt
@@ -93,6 +93,40 @@ class FunctionalNamingForHostnamesRuleTest {
     }
 
     @Test
+    fun `(must, should, may)FollowFunctionalNaming should return no violations if audience is null`() {
+        @Language("YAML")
+        val content = """
+            openapi: 3.0.1
+            info:
+              x-audience:
+            servers:
+              - url: "infrastructure-service.zalandoapis.com"
+        """.trimIndent()
+        val context = DefaultContextFactory().getOpenApiContext(content)
+
+        assertThat(rule.mustFollowFunctionalNaming(context)).isEmpty()
+        assertThat(rule.shouldFollowFunctionalNaming(context)).isEmpty()
+        assertThat(rule.mayFollowFunctionalNaming(context)).isEmpty()
+    }
+
+    @Test
+    fun `(must, should, may)FollowFunctionalNaming should return no violations if audience is invalid`() {
+        @Language("YAML")
+        val content = """
+            openapi: 3.0.1
+            info:
+              x-audience: invalid-audience
+            servers:
+              - url: "infrastructure-service.zalandoapis.com"
+        """.trimIndent()
+        val context = DefaultContextFactory().getOpenApiContext(content)
+
+        assertThat(rule.mustFollowFunctionalNaming(context)).isEmpty()
+        assertThat(rule.shouldFollowFunctionalNaming(context)).isEmpty()
+        assertThat(rule.mayFollowFunctionalNaming(context)).isEmpty()
+    }
+
+    @Test
     fun `(must, should, may)FollowFunctionalNaming should return no violations for 'external-partner' audience and url from a exception list`() {
         val context = getOpenApiContextWithAudienceAndHostname("external-partner", "api-sandbox.merchants.zalando.com")
 


### PR DESCRIPTION
Fixing the duplicate functional hostname violations that appear in case of missing, `null`, or invalid `x-audience` that are preconditions for this check. The idea is to silently ignore the functional hostname check if no proper audience is provided.

Example output copied from new Backstage API Linter:
![image](https://user-images.githubusercontent.com/18184975/165592982-566aad29-617d-4a28-8d3b-2faecb454ba7.png)
![image](https://user-images.githubusercontent.com/18184975/165593042-f6fcbd42-a678-40f2-bff5-e29fd055447b.png)
![image](https://user-images.githubusercontent.com/18184975/165593086-4177a47a-d61c-4490-831c-d5d747f1de5a.png)

