### PR TITLE
Update ProprietaryHeadersRuleTest.kt

### DIFF
--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ProprietaryHeadersRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ProprietaryHeadersRuleTest.kt
@@ -43,7 +43,7 @@ class ProprietaryHeadersRuleTest {
 
     @Test
     fun `validateResponseHeaders should return no violation for a specified proprietary header`() {
-        val violations = rule.validateResponseHeaders(withRequestHttpHeader("X-Flow-ID"))
+        val violations = rule.validateResponseHeaders(withResponseHttpHeader("X-Flow-ID"))
 
         assertThat(violations).isEmpty()
     }


### PR DESCRIPTION
Fixes #1404

`validateResponseHeaders should return no violation for a specified proprietary header`

