### PR TITLE
Add rule to check NoContent response

### DIFF
--- a/cli/zally/integration_test.go
+++ b/cli/zally/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package main
@@ -108,11 +109,12 @@ func TestIntegrationNotReceiveDeprecationMessage(t *testing.T) {
 func assertMoreThanZeroViolations(t *testing.T, out string, e error) {
 	must, should, may, hint := countViolations(out)
 
+	assert.NotNil(t, e, "Error should be not nil")
 	assert.True(t, must > 0, "Number of MUST violations should be > 0")
 	assert.True(t, should > 0, "Number of SHOULD violations should be > 0")
 	assert.True(t, may > 0, "Number of MAY violations should be > 0")
-	assert.Equal(t, 0, hint, "No HINTS ar expected")
-	assert.NotNil(t, e, "Error should be not nil")
+	assert.Equal(t, 0, hint, "No HINTS expected")
+
 }
 
 func countViolations(out string) (int, int, int, int) {

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/util/HttpStatus.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/util/HttpStatus.kt
@@ -1,0 +1,7 @@
+package org.zalando.zally.core.util
+
+enum class HttpStatus(val code: Int, val statusText: String) {
+
+    // 2xx status codes
+    NoContent(204, "No Content")
+}

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesRule.kt
@@ -7,6 +7,7 @@ import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
+import org.zalando.zally.core.util.HttpStatus
 
 /**
  * Validate that HTTP methods and statuses align as expected
@@ -35,6 +36,10 @@ class UseStandardHttpStatusCodesRule(rulesConfig: Config) {
     companion object {
         fun buildWellUnderstoodViolationMessage(path: String, status: String, method: String) =
             "Path $path should not use $status status code for $method operation"
+
+        fun noContentViolationMessage(statusCode: String) =
+            "$statusCode response should have no payload defined"
+
     }
 
     /**
@@ -83,6 +88,28 @@ class UseStandardHttpStatusCodesRule(rulesConfig: Config) {
                 context.violation("$status is not a well-understood response code", response)
             }
         }
+
+    @Check(severity = Severity.SHOULD)
+    fun checkThatNoContentResponseHasNoContentDefined(context: Context): List<Violation> =
+        context.validateResponses(
+            operationFilter = { (method, _) ->
+                method in listOf(
+                    PathItem.HttpMethod.PUT,
+                    PathItem.HttpMethod.PATCH,
+                    PathItem.HttpMethod.DELETE
+                )
+            },
+            responseFilter = { (code, response) ->
+                code.toInt() == HttpStatus.NoContent.code && response?.content.orEmpty().isNotEmpty()
+            },
+            action = { (key, response) ->
+                if (response == null) {
+                    emptyList<Violation>()
+                } else {
+                    listOf(context.violation(noContentViolationMessage(key), response))
+                }
+            }
+        )
 
     private fun isAllowed(method: PathItem.HttpMethod, statusCode: String): Boolean {
         val allowedMethods = wellUnderstoodResponseCodesAndVerbs[statusCode.lowercase()].orEmpty()

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesRule.kt
@@ -33,13 +33,12 @@ class UseStandardHttpStatusCodesRule(rulesConfig: Config) {
 
     private val standardResponseCodes = rulesConfig.getStringList("${javaClass.simpleName}.standard")
 
-    companion object {
-        fun buildWellUnderstoodViolationMessage(path: String, status: String, method: String) =
+    companion object Messages {
+        fun wellUnderstoodViolationMessage(path: String, status: String, method: String) =
             "Path $path should not use $status status code for $method operation"
 
         fun noContentViolationMessage(statusCode: String) =
             "$statusCode response should have no payload defined"
-
     }
 
     /**
@@ -54,7 +53,7 @@ class UseStandardHttpStatusCodesRule(rulesConfig: Config) {
                 operation?.responses.orEmpty()
                     .filterKeys { status -> !isAllowed(method, status) }
                     .map { (status, response) ->
-                        context.violation(buildWellUnderstoodViolationMessage(pathName, status, method.name), response)
+                        context.violation(wellUnderstoodViolationMessage(pathName, status, method.name), response)
                     }
             }
         }

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesRule.kt
@@ -100,7 +100,7 @@ class UseStandardHttpStatusCodesRule(rulesConfig: Config) {
                 )
             },
             responseFilter = { (code, response) ->
-                code.toInt() == HttpStatus.NoContent.code && response?.content.orEmpty().isNotEmpty()
+                code == HttpStatus.NoContent.code.toString() && response?.content.orEmpty().isNotEmpty()
             },
             action = { (key, response) ->
                 if (response == null) {

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesTest.kt
@@ -169,7 +169,7 @@ class UseStandardHttpStatusCodesTest {
         val violations = rule.checkWellUnderstoodResponseCodesUsage(api)
         assertThat(violations).isNotEmpty
         val violation = violations[0]
-        assertThat(violation.description).isEqualTo(UseStandardHttpStatusCodesRule.buildWellUnderstoodViolationMessage("/pets", "202", "GET"))
+        assertThat(violation.description).isEqualTo(UseStandardHttpStatusCodesRule.wellUnderstoodViolationMessage("/pets", "202", "GET"))
     }
 
     private fun apiWithGetResponseCode(responseCode: String): Context {

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesTest.kt
@@ -129,7 +129,7 @@ class UseStandardHttpStatusCodesTest {
                             properties: 
                               prop-1:
                                 type: string                              
-        """.trimIndent()
+            """.trimIndent()
         )
         val violations = rule.checkThatNoContentResponseHasNoContentDefined(context)
         assertThat(violations).hasSize(1)
@@ -149,7 +149,7 @@ class UseStandardHttpStatusCodesTest {
                   responses:
                     204:
                       description: Successful response
-        """.trimIndent()
+            """.trimIndent()
         )
         val violations = rule.checkThatNoContentResponseHasNoContentDefined(context)
         assertThat(violations).isEmpty()


### PR DESCRIPTION
Add a rule which checks that `204` response has no content defined.

Fixes #1403 