### PR TITLE
fix broken links to zally-api.yaml in documentation #1428

### DIFF
--- a/documentation/operation.md
+++ b/documentation/operation.md
@@ -8,7 +8,7 @@
 
 Zally Server is the core of Zally tools and also the only component of the minimal
 setup. It provides a
-[well-defined RESTful API](../server/src/main/resources/api/zally-api.yaml) to
+[well-defined RESTful API](../server/zally-server/src/main/resources/api/zally-api.yaml) to
 lint APIs, get information about past lintings, as well as provide information
 about implemented rules and statistics.
 

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -42,7 +42,7 @@ And here is a response example:
 ```
 
 Please consult
-[Zally API specification](../server/src/main/resources/api/zally-api.yaml).
+[Zally API specification](../server/zally-server/src/main/resources/api/zally-api.yaml).
 for further information. The well-defined API explains various linting variants
 and usage of other features like permalinks to results, statistics, etc.
 


### PR DESCRIPTION
Fixes #1428.