### PR TITLE
Address issue #1445 and fix failed test

### DIFF
--- a/server/zally-core/build.gradle.kts
+++ b/server/zally-core/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     kapt("com.google.auto.service:auto-service:1.0.1")
 
     api(project(":zally-rule-api"))
-    api("io.swagger.parser.v3:swagger-parser:2.1.9")
+    api("io.swagger.parser.v3:swagger-parser:2.1.12")
     api("io.github.config4k:config4k:0.5.0")
     implementation("com.google.auto.service:auto-service:1.0.1")
 

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/DefaultContextFactory.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/DefaultContextFactory.kt
@@ -102,7 +102,12 @@ class DefaultContextFactory(
 
         val parseResult = OpenAPIV3Parser().readContents(content, authorizationValue, parseOptions)
         return if (parseResult.openAPI === null) {
-            if (parseResult.messages.isEmpty() || parseResult.messages.contains("attribute openapi is missing")) {
+            val openApiIsMissing = parseResult.messages.contains("attribute openapi is missing")
+            val errorConstructingInstance = parseResult.messages.any {
+                it.contains("Cannot construct instance", ignoreCase = true)
+            }
+
+            if (parseResult.messages.isEmpty() || openApiIsMissing || errorConstructingInstance) {
                 ContentParseResult.NotApplicable()
             } else {
                 ContentParseResult.ParsedWithErrors(parseResult.messages.filterNotNull().map(::errorToViolation))

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
@@ -24,6 +24,16 @@ class DefaultContextFactoryTest {
     }
 
     @Test
+    fun `OPEN API -- Openapi property is expected to be String according to the OpenAPI3 spec`() {
+        @Language("YAML")
+        val content = """
+                openapi: {la: 3.0.0}
+            """
+        val result = defaultContextFactory.parseOpenApiContext(content)
+        assertThat(result).resultsInParsedWithErrors()
+    }
+
+    @Test
     fun `OPEN API -- not applicable when content does not contain the openapi property`() {
         @Language("YAML")
         val content = """

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
@@ -1,10 +1,12 @@
 package org.zalando.zally.core
 
+import com.fasterxml.jackson.core.JsonPointer
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.zalando.zally.core.ContentParseResultAssert.Companion.assertThat
+import org.zalando.zally.rule.api.Violation
 
 class DefaultContextFactoryTest {
 

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
@@ -15,6 +15,15 @@ class DefaultContextFactoryTest {
     //
 
     @Test
+    fun `OPEN API -- not applicable when content is a String without any properties`() {
+        @Language("YAML")
+        val content = "Pets API".trimIndent()
+        val result = defaultContextFactory.parseOpenApiContext(content)
+
+        assertThat(result).resultsInNotApplicable()
+    }
+
+    @Test
     fun `OPEN API -- not applicable when content does not contain the openapi property`() {
         @Language("YAML")
         val content = """

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
@@ -30,7 +30,12 @@ class DefaultContextFactoryTest {
                 openapi: {la: 3.0.0}
             """
         val result = defaultContextFactory.parseOpenApiContext(content)
-        assertThat(result).resultsInParsedWithErrors()
+        assertThat(result).resultsInErrors(
+            Violation(
+                description = "attribute openapi is not of type `string`",
+                pointer = JsonPointer.empty()
+            )
+        )
     }
 
     @Test

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/RestApiViolationsTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/RestApiViolationsTest.kt
@@ -118,14 +118,16 @@ class RestApiViolationsTest : RestApiBaseTest() {
 
     @Test
     fun shouldRespondWithViolationWhenApiDefinitionFieldIsNotValidSwaggerDefinition() {
+        val rule101Link = "https://zalando.github.io/restful-api-guidelines/#101"
         val response = sendApiDefinition(
             ApiDefinitionRequest.fromJson("\"no swagger definition\"")
         )
 
         assertThat(response.violations).hasSize(5)
         assertThat(response.violations[0].title).isEqualTo("provide API specification using OpenAPI")
-        // TODO: fails with exception after switch to swagger-parser:2.1.9
-        // assertThat(response.violations[0].description).isEqualTo("attribute openapi is not of type `object`")
+        // the input is just a string, it has no attributes
+        assertThat(response.violations[0].description).isEqualTo("attribute  is not of type `object`")
+        assertThat(response.violations[0].ruleLink).isEqualTo(rule101Link)
         assertThat(response.violations[1].title).isEqualTo("TestCheckIsOpenApi3")
         assertThat(response.externalId).isNotNull()
     }


### PR DESCRIPTION
Addresses https://github.com/zalando/zally/issues/1445
As Zally does not support validation for relative refs, no new test cases to cover this scenario

After upgrading to io.swagger.parser.v3:swagger-parser:2.1.9 (from 2.0.32) the test case was failing due to different error message.

This error occured because of changes in OpenAPIDeserializer:
`rootMap = new ObjectMapper().convertValue(rootNode, Map.class);`
the convert to rootMap was introduced before trying to parse the rootNode. That's why it is not setting the correct message in the result. 

Before the upgrade the message was
`attribute openApi is not of type "object"`

After upgrade the `IllegalArgumentException` is handled by the library itself, setting the message to 
```
Cannot construct instance of `java.util.LinkedHashMap` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('no swagger definition') at [Source: UNKNOWN; byte offset: #UNKNOWN]
```

Aligned with @tkrop on the fix:
handle this exception as violation of [rule #101](https://opensource.zalando.com/restful-api-guidelines/#101)
Since there is 0 attributes in test example `"no swagger definition"` it is handled as ParseResult.NotApplicable with following details:
```
{
    externalId: "<some id>",
    title: "provide API specification using OpenAPI",
    description: "attribute  is not of type `object`",
    ruleLink: "https://zalando.github.io/restful-api-guidelines/#101",
   ....
}
```


