### PR TITLE
Add support for other auth-schemes (i.e. Basic-Auth)

### DIFF
--- a/cli/zally/app.go
+++ b/cli/zally/app.go
@@ -25,8 +25,18 @@ func CreateApp() *cli.App {
 			EnvVar: "ZALLY_URL",
 		},
 		cli.StringFlag{
+			Name:   "auth-scheme, as",
+			Usage:  "Scheme used for authentication `AUTH_SCHEME`",
+			EnvVar: "AUTH_SCHEME",
+		},
+		cli.StringFlag{
+			Name:   "auth-params, ap",
+			Usage:  "Parameters used for authentication `AUTH_PARAMS`",
+			EnvVar: "AUTH_PARAMS",
+		},
+		cli.StringFlag{
 			Name:   "token, t",
-			Usage:  "OAuth2 Token `OAUTH2_TOKEN`",
+			Usage:  "OAuth2 Token (When set will overload auth-scheme and -params) `OAUTH2_TOKEN`",
 			EnvVar: "TOKEN",
 		},
 		cli.StringFlag{

--- a/cli/zally/commands/lint.go
+++ b/cli/zally/commands/lint.go
@@ -42,8 +42,18 @@ func lint(c *cli.Context) error {
 		return domain.NewAppError(err, domain.ClientError)
 	}
 	skipSslVerification := c.Bool("skip-ssl-verification")
-	requestBuilder := utils.NewRequestBuilder(
-		c.GlobalString("linter-service"), c.GlobalString("token"), c.App)
+
+	var requestBuilder *utils.RequestBuilder
+
+	//If token is set, the Oauth2 auth-scheme will be used
+	if c.GlobalString("token") != "" {
+		requestBuilder = utils.NewRequestBuilder(
+			c.GlobalString("linter-service"), "Bearer", c.GlobalString("token"), c.App)
+	} else {
+		requestBuilder = utils.NewRequestBuilder(
+			c.GlobalString("linter-service"), c.GlobalString("auth-scheme"), c.GlobalString("auth-params"), c.App)
+	}
+
 	violations, err := doRequest(requestBuilder, data, skipSslVerification)
 	if err != nil {
 		return domain.NewAppError(err, domain.ServerError)

--- a/cli/zally/commands/lint_test.go
+++ b/cli/zally/commands/lint_test.go
@@ -2,10 +2,11 @@ package commands
 
 import (
 	"flag"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"net/http"
 	"net/http/httptest"
@@ -61,7 +62,7 @@ func TestDoRequest(t *testing.T) {
 		testServer := httptest.NewServer(http.HandlerFunc(handler))
 		defer testServer.Close()
 
-		requestBuilder := utils.NewRequestBuilder(testServer.URL, "", app)
+		requestBuilder := utils.NewRequestBuilder(testServer.URL, "Bearer", "", app)
 		data, _ := readFile("testdata/minimal_swagger.json")
 
 		violations, err := doRequest(requestBuilder, data, false)
@@ -78,7 +79,7 @@ func TestDoRequest(t *testing.T) {
 		testServer := httptest.NewServer(http.HandlerFunc(handler))
 		defer testServer.Close()
 
-		requestBuilder := utils.NewRequestBuilder(testServer.URL, "", app)
+		requestBuilder := utils.NewRequestBuilder(testServer.URL, "Bearer", "", app)
 		data, _ := readFile("testdata/minimal_swagger.json")
 
 		violations, err := doRequest(requestBuilder, data, false)
@@ -96,7 +97,7 @@ func TestDoRequest(t *testing.T) {
 		testServer := httptest.NewServer(http.HandlerFunc(handler))
 		defer testServer.Close()
 
-		requestBuilder := utils.NewRequestBuilder(testServer.URL, "", app)
+		requestBuilder := utils.NewRequestBuilder(testServer.URL, "Bearer", "", app)
 		data, _ := readFile("testdata/minimal_swagger.json")
 
 		violations, err := doRequest(requestBuilder, data, false)

--- a/cli/zally/commands/supported_rules.go
+++ b/cli/zally/commands/supported_rules.go
@@ -41,8 +41,17 @@ func listRules(c *cli.Context) error {
 		return domain.NewAppError(err, domain.ClientError)
 	}
 
-	requestBuilder := utils.NewRequestBuilder(
-		c.GlobalString("linter-service"), c.GlobalString("token"), c.App)
+	var requestBuilder *utils.RequestBuilder
+
+	//If token is set, the Oauth2 auth-scheme will be used
+	if c.GlobalString("token") != "" {
+		requestBuilder = utils.NewRequestBuilder(
+			c.GlobalString("linter-service"), "Bearer", c.GlobalString("token"), c.App)
+	} else {
+		requestBuilder = utils.NewRequestBuilder(
+			c.GlobalString("linter-service"), c.GlobalString("auth-scheme"), c.GlobalString("auth-params"), c.App)
+	}
+
 	rules, err := fetchRules(requestBuilder, ruleType, c.Bool("skip-ssl-verification"))
 	if err != nil {
 		return domain.NewAppError(err, domain.ServerError)

--- a/cli/zally/commands/supported_rules_test.go
+++ b/cli/zally/commands/supported_rules_test.go
@@ -2,13 +2,14 @@ package commands
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/zalando/zally/cli/zally/utils/formatters"
 
@@ -69,7 +70,7 @@ func TestFetchRules(t *testing.T) {
 		testServer := httptest.NewServer(http.HandlerFunc(handler))
 		defer testServer.Close()
 
-		requestBuilder := utils.NewRequestBuilder(testServer.URL, "", app)
+		requestBuilder := utils.NewRequestBuilder(testServer.URL, "Bearer", "", app)
 		rules, err := fetchRules(requestBuilder, "", false)
 
 		tests.AssertEquals(t, nil, err)
@@ -89,7 +90,7 @@ func TestFetchRules(t *testing.T) {
 		testServer := httptest.NewServer(http.HandlerFunc(handler))
 		defer testServer.Close()
 
-		requestBuilder := utils.NewRequestBuilder(testServer.URL, "", app)
+		requestBuilder := utils.NewRequestBuilder(testServer.URL, "Bearer", "", app)
 		rules, err := fetchRules(requestBuilder, "", false)
 
 		tests.AssertEquals(t, "Cannot submit file for linting. HTTP Status: 400, Response: Something went wrong", err.Error())
@@ -106,7 +107,7 @@ func TestFetchRules(t *testing.T) {
 		testServer := httptest.NewServer(http.HandlerFunc(handler))
 		defer testServer.Close()
 
-		requestBuilder := utils.NewRequestBuilder(testServer.URL, "", app)
+		requestBuilder := utils.NewRequestBuilder(testServer.URL, "Bearer", "", app)
 		fetchRules(requestBuilder, "must", false)
 	})
 }

--- a/cli/zally/utils/request_builder.go
+++ b/cli/zally/utils/request_builder.go
@@ -2,24 +2,27 @@ package utils
 
 import (
 	"fmt"
-	"github.com/urfave/cli"
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/urfave/cli"
 )
 
 // RequestBuilder builds Zally specific requests
 type RequestBuilder struct {
-	baseURL   string
-	token     string
-	userAgent string
+	baseURL        string
+	authScheme     string
+	authParameters string
+	userAgent      string
 }
 
 // NewRequestBuilder creates an instance of RequestBuilder
-func NewRequestBuilder(baseURL string, token string, app *cli.App) *RequestBuilder {
+func NewRequestBuilder(baseURL string, authScheme string, authParameters string, app *cli.App) *RequestBuilder {
 	var builder RequestBuilder
 	builder.baseURL = baseURL
-	builder.token = token
+	builder.authScheme = authScheme
+	builder.authParameters = authParameters
 	builder.userAgent = fmt.Sprintf("%s/%s", app.Name, app.Version)
 	return &builder
 }
@@ -39,8 +42,8 @@ func (r *RequestBuilder) Build(httpVerb string, uri string, body io.Reader) (*ht
 	request.Header.Add("Content-Type", "application/json")
 	request.Header.Add("User-Agent", r.userAgent)
 
-	if len(r.token) > 0 {
-		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	if len(r.authParameters) > 0 {
+		request.Header.Add("Authorization", fmt.Sprintf("%s %s", r.authScheme, r.authParameters))
 	}
 
 	return request, nil

--- a/cli/zally/utils/request_builder_test.go
+++ b/cli/zally/utils/request_builder_test.go
@@ -12,16 +12,16 @@ var app = cli.NewApp()
 
 func TestNewRequestBuilder(t *testing.T) {
 	t.Run("accepts_base_url_and_token", func(t *testing.T) {
-		builder := NewRequestBuilder("http://example.com", "some_token", app)
+		builder := NewRequestBuilder("http://example.com", "Bearer", "some_token", app)
 
 		tests.AssertEquals(t, "http://example.com", builder.baseURL)
-		tests.AssertEquals(t, "some_token", builder.token)
+		tests.AssertEquals(t, "some_token", builder.authParameters)
 	})
 }
 
 func TestRequestBuilderBuild(t *testing.T) {
 	t.Run("creates_absolute_url", func(t *testing.T) {
-		builder := NewRequestBuilder("http://example.com/base", "some_token", app)
+		builder := NewRequestBuilder("http://example.com/base", "Bearer", "some_token", app)
 		request, err := builder.Build("GET", "/my-path?abcd=efgh", nil)
 
 		tests.AssertEquals(t, "http://example.com/base/my-path?abcd=efgh", request.URL.String())
@@ -29,7 +29,7 @@ func TestRequestBuilderBuild(t *testing.T) {
 	})
 
 	t.Run("adds_auth_header_when_token_is_specified", func(t *testing.T) {
-		builder := NewRequestBuilder("http://example.com/", "some_token", app)
+		builder := NewRequestBuilder("http://example.com/", "Bearer", "some_token", app)
 		request, err := builder.Build("GET", "/my-path", nil)
 
 		tests.AssertEquals(t, "Bearer some_token", request.Header.Get("Authorization"))
@@ -39,7 +39,7 @@ func TestRequestBuilderBuild(t *testing.T) {
 	t.Run("adds_user_agent_with_app_name_and_version_header", func(t *testing.T) {
 		app.Name = "Zally-CLI"
 		app.Version = "1.1"
-		builder := NewRequestBuilder("http://example.com/", "", app)
+		builder := NewRequestBuilder("http://example.com/", "Bearer", "", app)
 		request, err := builder.Build("GET", "/my-path", nil)
 
 		tests.AssertEquals(t, "Zally-CLI/1.1", request.Header.Get("User-Agent"))
@@ -47,7 +47,7 @@ func TestRequestBuilderBuild(t *testing.T) {
 	})
 
 	t.Run("adds_no_auth_header_when_token_is_not_specified", func(t *testing.T) {
-		builder := NewRequestBuilder("http://example.com/", "", app)
+		builder := NewRequestBuilder("http://example.com/", "Bearer", "", app)
 		request, err := builder.Build("GET", "/my-path", nil)
 
 		tests.AssertEquals(t, "", request.Header.Get("Authorization"))
@@ -55,7 +55,7 @@ func TestRequestBuilderBuild(t *testing.T) {
 	})
 
 	t.Run("sets_proper_http_method", func(t *testing.T) {
-		builder := NewRequestBuilder("http://example.com/", "some_token", app)
+		builder := NewRequestBuilder("http://example.com/", "Bearer", "some_token", app)
 		request, err := builder.Build("HEAD", "/my-path", nil)
 
 		tests.AssertEquals(t, "HEAD", request.Method)
@@ -64,7 +64,7 @@ func TestRequestBuilderBuild(t *testing.T) {
 
 	t.Run("sets_proper_body", func(t *testing.T) {
 		body := []byte("Test body")
-		builder := NewRequestBuilder("http://example.com/", "some_token", app)
+		builder := NewRequestBuilder("http://example.com/", "Bearer", "some_token", app)
 		request, err := builder.Build("POST", "/my-path", bytes.NewBuffer(body))
 
 		reader, err := request.GetBody()


### PR DESCRIPTION
This fixes https://github.com/zalando/zally/issues/1506 and allows to set an auth-scheme and auth-parameters. This is fully backwards compatible and still allows for just the token to be set.