### PR TITLE
fix: web-ui Dockerfile updated to fix blank screen issue while using …

### DIFF
--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -4,14 +4,10 @@ MAINTAINER "http://zalando.github.io/"
 
 RUN apk --no-cache add curl
 
-COPY package.json ./
-COPY yarn.lock ./
-
-RUN yarn --production
-
-COPY src ./src
-COPY server.js ./
+COPY ./ ./
+RUN yarn
+RUN yarn build
 
 EXPOSE 3000
 
-CMD ["node", "server.js"]
+CMD ["yarn", "start"]


### PR DESCRIPTION
Web-ui Dockerfile updated to fix: https://github.com/zalando/zally/issues/1406

# Step to reproduce the issue

1. Checkout main branch
2. Run `docker compose build`
3. Run `docker compose up -d`
4. Access Web UI in the browser, it will open a blank with the below error:

```
bundle.js:1 Uncaught SyntaxError: Unexpected token '<' (at bundle.js:1:1)
```


# How to test 
1. Apply these changes or check out this branch 
2. Run `docker compose build`
3. Run `docker compose up -d`
4. Access Web UI in the browser, it will open zallu UI without any errors