### PR TITLE
Add Preference-Applied header to the allowed response headers.

### DIFF
--- a/server/zally-ruleset-zalando/src/main/resources/reference.conf
+++ b/server/zally-ruleset-zalando/src/main/resources/reference.conf
@@ -177,6 +177,7 @@ ProprietaryHeadersRule {
     "Location",
     "P3P",
     "Pragma",
+    "Preference-Applied",
     "Proxy-Authenticate",
     "Public-Key-Pins",
     "Retry-After",


### PR DESCRIPTION
According to the [MAY consider to support Prefer header to handle processing preferences [181]](https://opensource.zalando.com/restful-api-guidelines/#181) rule, Zally shouldn't complain about `Preference-Applied` header in the responses.