### PR TITLE
Update action/cache to v4

### DIFF
--- a/.github/workflows/build-zally.yml
+++ b/.github/workflows/build-zally.yml
@@ -17,7 +17,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Zally: A minimalistic, simple-to-use OpenAPI 2 and 3 linter
 
-[![Build Status](https://travis-ci.org/zalando/zally.svg?branch=master)](https://travis-ci.org/zalando/zally)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/05a7515011504c06b1cb35ede27ac7d4)](https://www.codacy.com/app/zally/zally?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=zalando/zally&amp;utm_campaign=Badge_Grade)
+![Build Status](https://github.com/zalando/riptide/workflows/build/badge.svg)
 [![Join the chat at https://gitter.im/zalando/zally](https://badges.gitter.im/zalando/zally.svg)](https://gitter.im/zalando/zally?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 <img src="logo.png" width="200" height="200" />


### PR DESCRIPTION
There is current a build warning. Will become an error soon.

> Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@v2. Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

https://github.com/actions/cache/discussions/1510:

> We are deprecating some versions of this action. We recommend upgrading to version v4 or v3 as soon as possible before March 1st, 2025.