### PR TITLE
Fix parsing of OpenApi 3.1 schemas

### DIFF
--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/DefaultContextFactory.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/DefaultContextFactory.kt
@@ -88,7 +88,7 @@ class DefaultContextFactory(
     private fun parseOpenApi(content: String, authorization: String?): ContentParseResult<SwaggerParseResult> {
         val parseOptions = ParseOptions()
         parseOptions.isResolve = true
-        // parseOptions.isResolveFully = true // https://github.com/swagger-api/swagger-parser/issues/682
+        parseOptions.isResolveFully = true // Needed to resolve references in OpenAPI 3.1.0
 
         val authorizationValue = when {
             authorization is String && propagateAuthorizationUrls.isNotEmpty() ->

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
@@ -3,14 +3,15 @@ package org.zalando.zally.core
 import com.fasterxml.jackson.core.JsonPointer
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.zalando.zally.core.ContentParseResultAssert.Companion.assertThat
+import org.zalando.zally.core.util.getAllParameters
 import org.zalando.zally.rule.api.Violation
 
 class DefaultContextFactoryTest {
 
     private val defaultContextFactory = DefaultContextFactory()
+    private val ref = "\$ref"
 
     //
     // OPEN API
@@ -53,20 +54,6 @@ class DefaultContextFactoryTest {
     }
 
     @Test
-    @Disabled("OpenAPI 3.1 seems now to be supported by latest swagger parser")
-    fun `OPEN API -- OpenAPI 3-1 is not applicable`() {
-        // The parsing results in no OpenAPI 3.1 object model until the latest
-        // parser is providing support. Than we can remove this test case and
-        // and enable the subsequent tests.
-        @Language("YAML")
-        val content = """
-                openapi: 3.1.0
-            """
-        val result = defaultContextFactory.parseOpenApiContext(content)
-        assertThat(result).resultsInNotApplicable()
-    }
-
-    @Test
     fun `OPEN API -- OpenAPI 3-1 without info and paths succeeds with messages`() {
         // The parsing results in a valid OpenAPI 3.1 object model, but
         // with messages that `info` and `paths` are missing. Let the
@@ -82,7 +69,6 @@ class DefaultContextFactoryTest {
     }
 
     @Test
-    @Disabled("OpenAPI 3.1 is not supported by latest swagger parser yet")
     fun `OPEN API -- OpenAPI 3-1 with oauth but without scopes succeeds`() {
         @Language("YAML")
         val content = """
@@ -103,7 +89,6 @@ class DefaultContextFactoryTest {
     }
 
     @Test
-    @Disabled("OpenAPI 3.1 is not supported by latest swagger parser yet")
     fun `OPEN API -- OpenAPI 3-1 is recognised as an OpenAPI3 spec`() {
         @Language("YAML")
         val content = """
@@ -117,6 +102,50 @@ class DefaultContextFactoryTest {
         assertThat(result).resultsInSuccess()
         val success = result as ContentParseResult.ParsedSuccessfully
         assertThat(success.result.isOpenAPI3()).isTrue()
+    }
+
+    @Test
+    fun `OPEN API -- OpenAPI 3-1-0 all refs are resolved`() {
+        @Language("YAML")
+        val content = """
+                openapi: '3.1.0'
+                info:
+                  title: API 1
+                  contact: 
+                    name: "Team One"
+                  version: 1.0.0
+                paths:
+                  /items/{item-id}:
+                    get:
+                      parameters:
+                        - $ref: "#/components/parameters/PathParameter"
+                      responses: 
+                        default:
+                         description: Response
+                         content:                        
+                           application/json:
+                             schema: 
+                               type: string
+                components: 
+                  parameters:
+                    PathParameter:
+                      in: path  
+                      name: item-id                            
+                      description: The id of the pet to retrieve
+                      required: true
+                      schema:
+                        type: string
+            """.trimIndent()
+
+        val result = defaultContextFactory.parseOpenApiContext(content)
+        assertThat(result).resultsInSuccess()
+        val success = result as ContentParseResult.ParsedSuccessfully
+        assertThat(success.result.isOpenAPI3()).isTrue()
+
+        val params = success.result.api.getAllParameters()
+        assertThat(params).hasSize(2)
+        assertThat(params).allMatch { it.name == "item-id" }
+        assertThat(params).allMatch { it.`$ref` == null }
     }
 
     @Test
@@ -334,7 +363,7 @@ class DefaultContextFactoryTest {
                     200:
                       description: List of nodes.
                       schema:
-                        ${'$'}ref: '#/definitions/ReadNode'
+                        $ref: '#/definitions/ReadNode'
             definitions:
               WriteNode:
                 type: object
@@ -344,10 +373,10 @@ class DefaultContextFactoryTest {
                   children:
                     type: array
                     items:
-                      ${'$'}ref: '#/definitions/WriteNode'
+                      $ref: '#/definitions/WriteNode'
               ReadNode:
                 allOf:
-                  - ${'$'}ref: '#/definitions/WriteNode'
+                  - $ref: '#/definitions/WriteNode'
                   - type: object
                     properties:
                       extra: # property that WriteNode doesn't have
@@ -355,7 +384,7 @@ class DefaultContextFactoryTest {
                       children: # children redefined to be ReadNode rather than WriteNode
                         type: array
                         items:
-                          ${'$'}ref: '#/definitions/ReadNode'
+                          $ref: '#/definitions/ReadNode'
         """.trimIndent()
         val result = defaultContextFactory.parseSwaggerContext(content)
         assertThat(result).resultsInSuccess()
@@ -367,8 +396,6 @@ class DefaultContextFactoryTest {
     fun `OpenAPI Resolve NPE workaround is avoided when converted Swagger has components with null schemas`() {
         // This Swagger, after being converted, causes the `components` property to exist (not
         // null), but having a null `schemas`, which causes the NPE.
-        val ref = "\$ref"
-
         @Language("YAML")
         val content = """
           swagger: '2.0'

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/PathParameterRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/PathParameterRuleTest.kt
@@ -341,4 +341,44 @@ class PathParameterRuleTest {
 
         assertThat(violations).isEmpty()
     }
+
+    @Test
+    internal fun `return no violations when validating referenced parameters on OpenAPI 3-1-0`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+            """
+            openapi: '3.1.0'
+            info:
+              title: API 1
+              contact: 
+                name: "Team One"
+              version: 1.0.0
+            paths:
+              /items/{item-id}:
+                get:
+                  parameters:
+                    - ${'$'}ref: "#/components/parameters/PathParameter"
+                  responses: 
+                    default:
+                     description: Response
+                     content:                        
+                       application/json:
+                         schema: 
+                           type: string
+            components: 
+              parameters:
+                PathParameter:
+                  in: path  
+                  name: item-id                            
+                  description: The id of the pet to retrieve
+                  required: true
+                  schema:
+                    type: string
+            """.trimIndent()
+        )
+
+        val violations = rule.checkSchemaOrContentProperty(context)
+
+        assertThat(violations).isEmpty()
+    }
 }


### PR DESCRIPTION
The application wasn't being able to correctly parse OpenApi 3.1 schemas, the parameters references wasn't being properly fetched which was causing an unexpected NPE when doing the validation.

More info in the issue https://github.com/zalando/zally/issues/1528